### PR TITLE
feat(seo): SEO de marca dos parceiros — páginas de instituição + link interno (Fases 1-2)

### DIFF
--- a/app/faculdades/[slug]/FaculdadePageClient.tsx
+++ b/app/faculdades/[slug]/FaculdadePageClient.tsx
@@ -183,17 +183,26 @@ export default function FaculdadePageClient({ institution, initialCourses }: Pro
                   Faculdade parceira
                 </span>
                 <h1 className="font-display text-4xl md:text-5xl lg:text-[56px] font-semibold text-white leading-[1.05]">
-                  Faculdade <span className="italic text-white/85">{institution.name}</span>
+                  Bolsas de Estudo na <span className="italic text-white/85">{institution.name}</span>
                 </h1>
                 <p className="font-mono text-[11px] tracking-[0.14em] uppercase text-white/60 mt-4">
-                  {typeLabels[institution.type]}
+                  Faculdade {typeLabels[institution.type]}
                   {institution.founded ? ` · Desde ${institution.founded}` : ''}
                   {yearsActive ? ` · ${yearsActive} anos` : ''}
                 </p>
               </div>
             </div>
 
-            <p className="text-white/80 text-[15px] md:text-[17px] leading-relaxed max-w-3xl">
+            {/* Resposta direta GEO (40-60 palavras): responde "como conseguir bolsa
+                na {marca}" no topo, pra extração por AI Overviews/ChatGPT/Perplexity. */}
+            <p data-speakable="answer" className="text-white text-[16px] md:text-[18px] leading-relaxed max-w-3xl font-medium">
+              Para conseguir bolsa de estudo na {institution.name}, busque o curso aqui no
+              Bolsa Click, compare as ofertas e inscreva-se grátis — os descontos chegam a
+              até 80% nas mensalidades, em cursos {institution.modalities.includes('EAD') ? 'EAD e presenciais' : 'presenciais'} reconhecidos
+              pelo MEC.
+            </p>
+
+            <p className="text-white/80 text-[15px] md:text-[17px] leading-relaxed max-w-3xl mt-4">
               {institution.description}
             </p>
 

--- a/app/faculdades/[slug]/page.tsx
+++ b/app/faculdades/[slug]/page.tsx
@@ -96,6 +96,14 @@ export default async function FaculdadeDetailPage({
   const aggregateRating = buildAggregateRatingSchema(reviewSummary)
   const institutionCourses = await getInstitutionCourses(institution.name)
 
+  // Faixa de preço REAL das ofertas (anti-hallucination: só preços vindos da API,
+  // nunca inventado). Alimenta AggregateOffer pra rich result + citabilidade em IA.
+  const offerPrices = institutionCourses
+    .map((c) => c.minPrice ?? 0)
+    .filter((p) => p > 0)
+  const lowPrice = offerPrices.length ? Math.min(...offerPrices) : null
+  const highPrice = offerPrices.length ? Math.max(...offerPrices) : null
+
   const educationalOrgSchema = {
     '@context': 'https://schema.org',
     '@type': 'EducationalOrganization',
@@ -117,6 +125,18 @@ export default async function FaculdadeDetailPage({
       },
     }),
     ...(aggregateRating && { aggregateRating }),
+    ...(lowPrice && {
+      makesOffer: {
+        '@type': 'AggregateOffer',
+        priceCurrency: 'BRL',
+        lowPrice,
+        ...(highPrice && highPrice !== lowPrice && { highPrice }),
+        offerCount: institutionCourses.length,
+        category: 'Bolsa de estudo',
+        availability: 'https://schema.org/InStock',
+        description: `Mensalidades com bolsa de estudo na ${institution.name} a partir de R$ ${lowPrice.toFixed(0)}/mês.`,
+      },
+    }),
   }
 
   const faqSchema = {


### PR DESCRIPTION
## Objetivo
Fazer o bolsaclick rankear pra buscas de marca dos **parceiros** — "bolsa de estudo anhanguera", "anhanguera ead bolsa", etc. — replicável pros 6 parceiros (Anhanguera, Unopar, Pitágoras, Ampli, Unime, Estácio). Parceiros são whitelist do CLAUDE.md (pode citar por nome).

## Fase 1 — template de instituição (`app/faculdades/[slug]/`)
A página é templated → melhora os 6 de uma vez:
- **H1:** "Faculdade {marca}" → **"Bolsas de Estudo na {marca}"**.
- **Bloco de resposta direta GEO** (`data-speakable`, ~50 palavras) "como conseguir bolsa na {marca}".
- **`AggregateOffer` schema** com faixa de preço **real** (anti-hallucination).

## Fase 2 — link interno com âncora de marca
- **Pillar `/bolsas-de-estudo`:** nova seção "Bolsas de estudo por faculdade parceira" linkando os 6 parceiros (antes só citava em texto, sem link).
- **Página de curso `/cursos/[slug]`:** seção "Faculdades com bolsa em {curso}" linkando **só as instituições que realmente ofertam o curso** (via brand das ofertas) — âncora "Bolsa de {curso} na {marca}".

## Notas
- Baixo risco de duplicata (entidades distintas). Sem mudança no gate de qualidade.
- **Caveat:** termo de marca puro ("anhanguera") tende a ir pro site oficial; alvo real é o modificador comercial.
- Build local falhou por queda transitória de conexão com DB (P1001) no prerender de `/comparar/*` — não relacionado (tsc limpo). Validar pelos checks da Vercel.

## Próximas fases (fora deste PR)
- **Fase 3:** conteúdo dedicado por marca (blog).
- **Fase 4:** city pages de faculdade (consolidar URL `/[city]`↔`/em/[city]` + estabilizar o flip-flop de noindex, igual fizemos nos cursos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)