### PR TITLE
feat(seo): internal links pras páginas de marca (logos + âncoras curso×marca)

### DIFF
--- a/app/cursos-profissionalizantes/CursosProfissionalizantesClient.tsx
+++ b/app/cursos-profissionalizantes/CursosProfissionalizantesClient.tsx
@@ -410,15 +410,22 @@ export default function CursosProfissionalizantesClient({ offers }: Props) {
           </p>
           <div className="flex flex-wrap items-center justify-center gap-x-12 gap-y-6 grayscale opacity-70">
             {PARTNERS.map((p) => (
-              <Image
+              <Link
                 key={p.name}
-                src={p.src}
-                alt={p.name}
-                width={140}
-                height={36}
-                className="h-9 w-auto object-contain"
-                unoptimized
-              />
+                href={`/faculdades/${p.name.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')}`}
+                aria-label={`Bolsas de estudo na ${p.name}`}
+                title={`Faculdade ${p.name}`}
+                className="transition-opacity hover:opacity-100"
+              >
+                <Image
+                  src={p.src}
+                  alt={p.name}
+                  width={140}
+                  height={36}
+                  className="h-9 w-auto object-contain"
+                  unoptimized
+                />
+              </Link>
             ))}
           </div>
         </div>

--- a/app/cursos/CursosPageClient.tsx
+++ b/app/cursos/CursosPageClient.tsx
@@ -251,15 +251,22 @@ export default function CursosPageClient({ courses }: CursosPageClientProps) {
           </p>
           <div className="flex flex-wrap items-center justify-center gap-x-12 gap-y-6 grayscale opacity-70">
             {PARTNERS.map((p) => (
-              <Image
+              <Link
                 key={p.name}
-                src={p.src}
-                alt={p.name}
-                width={140}
-                height={36}
-                className="h-9 w-auto object-contain"
-                unoptimized
-              />
+                href={`/faculdades/${p.name.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')}`}
+                aria-label={`Bolsas de estudo na ${p.name}`}
+                title={`Faculdade ${p.name}`}
+                className="transition-opacity hover:opacity-100"
+              >
+                <Image
+                  src={p.src}
+                  alt={p.name}
+                  width={140}
+                  height={36}
+                  className="h-9 w-auto object-contain"
+                  unoptimized
+                />
+              </Link>
             ))}
           </div>
         </div>

--- a/app/cursos/[slug]/CursoPageClient.tsx
+++ b/app/cursos/[slug]/CursoPageClient.tsx
@@ -10,6 +10,7 @@ import {
   TrendingUp,
 } from 'lucide-react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
 import { FeaturedCourseData } from '../_data/types'
@@ -447,17 +448,38 @@ export default function CursoPageClient({
           </p>
           <div className="flex flex-wrap items-center justify-center gap-x-12 gap-y-6 grayscale opacity-70">
             {PARTNERS.map((p) => (
-              <Image
+              <Link
                 key={p.name}
-                src={p.src}
-                alt={p.name}
-                width={140}
-                height={36}
-                className="h-9 w-auto object-contain"
-                unoptimized
-              />
+                href={`/faculdades/${p.name.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')}`}
+                aria-label={`Bolsas de estudo na ${p.name}`}
+                title={`Faculdade ${p.name}`}
+                className="transition-opacity hover:opacity-100"
+              >
+                <Image
+                  src={p.src}
+                  alt={p.name}
+                  width={140}
+                  height={36}
+                  className="h-9 w-auto object-contain"
+                  unoptimized
+                />
+              </Link>
             ))}
           </div>
+
+          {/* Links de texto com âncora rica (curso + marca) → reforço de internal linking */}
+          <ul className="mt-8 flex flex-wrap items-center justify-center gap-x-3 gap-y-2 max-w-3xl mx-auto">
+            {PARTNERS.slice(0, 4).map((p) => (
+              <li key={`brand-link-${p.name}`}>
+                <Link
+                  href={`/faculdades/${p.name.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')}`}
+                  className="inline-flex items-center px-3.5 py-1.5 rounded-full border border-hairline bg-white text-[13px] text-ink-700 hover:border-ink-900 hover:text-ink-900 transition-colors"
+                >
+                  Bolsa de {cursoMetadata.name} na {p.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
         </div>
       </section>
 

--- a/app/cursos/[slug]/[city]/CursoCidadeClient.tsx
+++ b/app/cursos/[slug]/[city]/CursoCidadeClient.tsx
@@ -466,15 +466,22 @@ export default function CursoCidadeClient({
           </p>
           <div className="flex flex-wrap items-center justify-center gap-x-12 gap-y-6 grayscale opacity-70 min-h-[80px]">
             {PARTNERS.map((p) => (
-              <Image
+              <Link
                 key={p.name}
-                src={p.src}
-                alt={p.name}
-                width={140}
-                height={36}
-                className="h-9 w-auto object-contain"
-                unoptimized
-              />
+                href={`/faculdades/${p.name.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')}`}
+                aria-label={`Bolsas de estudo na ${p.name}`}
+                title={`Faculdade ${p.name}`}
+                className="transition-opacity hover:opacity-100"
+              >
+                <Image
+                  src={p.src}
+                  alt={p.name}
+                  width={140}
+                  height={36}
+                  className="h-9 w-auto object-contain"
+                  unoptimized
+                />
+              </Link>
             ))}
           </div>
         </div>

--- a/app/graduacao/GraduacaoClient.tsx
+++ b/app/graduacao/GraduacaoClient.tsx
@@ -442,15 +442,22 @@ export default function GraduacaoClient({ offers }: Props) {
           </p>
           <div className="flex flex-wrap items-center justify-center gap-x-12 gap-y-6 grayscale opacity-70">
             {PARTNERS.map((p) => (
-              <Image
+              <Link
                 key={p.name}
-                src={p.src}
-                alt={p.name}
-                width={140}
-                height={36}
-                className="h-9 w-auto object-contain"
-                unoptimized
-              />
+                href={`/faculdades/${p.name.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')}`}
+                aria-label={`Bolsas de estudo na ${p.name}`}
+                title={`Faculdade ${p.name}`}
+                className="transition-opacity hover:opacity-100"
+              >
+                <Image
+                  src={p.src}
+                  alt={p.name}
+                  width={140}
+                  height={36}
+                  className="h-9 w-auto object-contain"
+                  unoptimized
+                />
+              </Link>
             ))}
           </div>
         </div>

--- a/app/pos-graduacao/PosGraduacaoClient.tsx
+++ b/app/pos-graduacao/PosGraduacaoClient.tsx
@@ -418,15 +418,22 @@ export default function PosGraduacaoClient({ offers }: Props) {
           </p>
           <div className="flex flex-wrap items-center justify-center gap-x-12 gap-y-6 grayscale opacity-70">
             {PARTNERS.map((p) => (
-              <Image
+              <Link
                 key={p.name}
-                src={p.src}
-                alt={p.name}
-                width={140}
-                height={36}
-                className="h-9 w-auto object-contain"
-                unoptimized
-              />
+                href={`/faculdades/${p.name.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')}`}
+                aria-label={`Bolsas de estudo na ${p.name}`}
+                title={`Faculdade ${p.name}`}
+                className="transition-opacity hover:opacity-100"
+              >
+                <Image
+                  src={p.src}
+                  alt={p.name}
+                  width={140}
+                  height={36}
+                  className="h-9 w-auto object-contain"
+                  unoptimized
+                />
+              </Link>
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Objetivo
Reforçar o internal linking para as páginas de marca (`/faculdades/[marca]`) — Estácio, Anhanguera e demais parceiros — distribuindo autoridade e usando âncoras com keyword.

## O que muda
- **Logos clicáveis**: os strips "Faculdades parceiras" (6 páginas: `/cursos`, `/graduacao`, `/pos-graduacao`, curso, curso+cidade, profissionalizantes) eram `<Image>` puro; agora cada logo é `<Link>` para `/faculdades/[marca]` com `aria-label`/`title` "Bolsas de estudo na [marca]".
- **Âncoras ricas curso×marca**: a página de curso ganha uma lista de links de texto "Bolsa de [curso] na [marca]" (Anhanguera, Estácio, Unopar, Pitágoras) → âncora com keyword apontando para a página de marca.

## Notas
- Slugs derivados do nome (normalize/sem acento) → batem com os slugs ativos (anhanguera, estacio, unopar, pitagoras, ampli, unime).
- `tsc` + `lint` limpos.
- Não inclui uma alteração não relacionada em `app/checkout/matricula/page.tsx` (campo de voucher) que já estava no working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)