### PR TITLE
fix(vitrine): graduação exibia mensalidade dividida pela duração (R$3/mês)

### DIFF
--- a/app/graduacao/GraduacaoClient.tsx
+++ b/app/graduacao/GraduacaoClient.tsx
@@ -224,12 +224,10 @@ export default function GraduacaoClient({ offers }: Props) {
             <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-5 items-stretch stagger-rise">
               {offers.map((o) => {
                 const logo = getBrandLogo(o.brand)
-                const monthly = o.durationInMonths && o.durationInMonths > 0
-                  ? o.minPrice / o.durationInMonths
-                  : o.minPrice
-                const monthlyFull = o.durationInMonths && o.durationInMonths > 0
-                  ? o.maxPrice / o.durationInMonths
-                  : o.maxPrice
+                // Graduação: minPrice/maxPrice JÁ são a mensalidade (ex.: R$108,39),
+                // não o total do curso — não dividir por duração (isso gerava R$3,61/mês).
+                const monthly = o.minPrice
+                const monthlyFull = o.maxPrice
                 return (
                   <li key={`${o.id}-${o.searchTerm}-${o.modality}`} className="h-full">
                     <Link


### PR DESCRIPTION
## Bug
Na vitrine "Ofertas em destaque" de `/graduacao`, os preços apareciam absurdos (ex.: **R\$ 3,61/mês**, "De R\$ 9,12").

## Causa
O card dividia `minPrice/maxPrice` por `durationInMonths`. Mas na **graduação** o `minPrice` da Tartarus **já é a mensalidade** (ex.: R\$ 108,39), não o total do curso → 108,39 ÷ 30 = R\$ 3,61.

## Fix
Graduação passa a usar `minPrice/maxPrice` direto (sem dividir). Pós e profissionalizante **mantêm** a divisão — lá o `minPrice` é o total do curso (ex.: MBA R\$1.274/10 = R\$127/mês), então a divisão está correta.

`tsc` + `lint` limpos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)