### PR TITLE
fix(build): limita pool de conexões do Prisma (evita 'too many clients' no build)

### DIFF
--- a/app/lib/prisma.ts
+++ b/app/lib/prisma.ts
@@ -1,9 +1,35 @@
 import { PrismaClient } from '@prisma/client'
 
+/**
+ * Limita o pool de conexões por client. Sem isso o Prisma usa o default
+ * (num_cpus * 2 + 1) por client; no `next build` cada worker que pré-renderiza
+ * as páginas estáticas abre seu próprio pool → o Postgres estoura
+ * ("too many clients already") e o build falha. Em serverless (Vercel) manter o
+ * pool baixo por instância também é a recomendação do Prisma.
+ *
+ * `connection_limit=1` mantém ~1 conexão por worker/instância; `pool_timeout`
+ * faz as queries concorrentes da mesma página aguardarem em fila em vez de falhar.
+ * Respeita um valor já presente na DATABASE_URL, se houver.
+ */
+function databaseUrlWithPool(): string | undefined {
+  const url = process.env.DATABASE_URL
+  if (!url) return undefined
+  try {
+    const u = new URL(url)
+    if (!u.searchParams.has('connection_limit')) u.searchParams.set('connection_limit', '1')
+    if (!u.searchParams.has('pool_timeout')) u.searchParams.set('pool_timeout', '20')
+    return u.toString()
+  } catch {
+    return url
+  }
+}
+
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
 }
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient()
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({ datasourceUrl: databaseUrlWithPool() })
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma


### PR DESCRIPTION
## Problema
O deploy falhava no `next build` durante a geração estática (635 páginas):
`PrismaClientInitializationError: Too many database connections opened: FATAL: sorry, too many clients already` (em `/bolsas-de-estudo`, `/llms.txt`, `/estudos/...`).

## Causa
O `PrismaClient` era criado sem limite de pool → usa o default (`nº_cpus * 2 + 1`) por client. No build, cada worker que pré-renderiza páginas abre o próprio pool → o Postgres (Railway) estoura o limite de conexões.

## Fix
`app/lib/prisma.ts` injeta `connection_limit=1` + `pool_timeout=20` na `DATABASE_URL` (respeitando valor já existente). ~1 conexão por worker/instância; queries concorrentes da mesma página aguardam em fila. É também a recomendação do Prisma para serverless (Vercel).

## Verificação
Build local que antes morria em ~158/635 agora **passa de 476/635 sem erro de conexão** (confirmado). `tsc` + `lint` limpos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)