### PR TITLE
feat(analytics): Meta Conversions API server-side + dedup no funil

### DIFF
--- a/app/(default)/curso/resultado/SearchResultClient.tsx
+++ b/app/(default)/curso/resultado/SearchResultClient.tsx
@@ -19,6 +19,7 @@ import { useForm } from 'react-hook-form'
 import { useRouter, useSearchParams } from 'next/navigation';
 import { getShowFiltersCourses } from '@/app/lib/api/get-courses-filter'
 import { usePostHogTracking } from '@/app/lib/hooks/usePostHogTracking'
+import { trackFbqDual } from '@/app/lib/analytics/fbq'
 import { normalizeAcademicLevel } from '@/app/lib/academic-level'
 import { titleCasePtBr } from '@/app/lib/utils/title-case'
 import { normalizeBrand } from '@/app/lib/utils/brand'
@@ -410,8 +411,19 @@ export default function SearchResultClient() {
         results_count: coursesCount,
         has_results: coursesCount > 0,
       })
+
+      // Meta Pixel + Conversions API - Search
+      if (courseNameForAPI) {
+        void trackFbqDual('Search', {
+          search_string: courseNameForAPI,
+          content_category: normalizedNivel || undefined,
+          city: cidade || undefined,
+          state: estado || undefined,
+          results_count: coursesCount,
+        })
+      }
     }
-  }, [showCourses, isLoading, courseNameForAPI, cidade, estado, modalidade, nivel, trackEvent])
+  }, [showCourses, isLoading, courseNameForAPI, cidade, estado, modalidade, nivel, normalizedNivel, trackEvent])
 
 
   // Filtrar por modalidade apenas se houver modalidade na URL

--- a/app/api/facebook/event/route.ts
+++ b/app/api/facebook/event/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { sendFacebookEvent, type FbUserData } from '@/app/lib/analytics/fb-capi'
+
+interface BodyUser {
+  email?: string
+  phone?: string
+  externalId?: string
+  firstName?: string
+  lastName?: string
+  city?: string
+  state?: string
+}
+
+interface Body {
+  event: string
+  event_id: string
+  properties?: Record<string, unknown>
+  user?: BodyUser
+  url?: string
+  referrer?: string
+  fbp?: string
+  fbc?: string
+}
+
+export async function POST(request: NextRequest) {
+  if (!process.env.FB_CONVERSIONS_ACCESS_TOKEN) {
+    return NextResponse.json({ ok: false, skipped: 'env_missing' }, { status: 200 })
+  }
+
+  let body: Body
+  try {
+    body = (await request.json()) as Body
+  } catch {
+    return NextResponse.json({ error: 'invalid_body' }, { status: 400 })
+  }
+
+  if (!body.event || !body.event_id) {
+    return NextResponse.json({ error: 'event_and_event_id_required' }, { status: 400 })
+  }
+
+  const clientIp =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    request.headers.get('x-real-ip') ??
+    undefined
+  const userAgent = request.headers.get('user-agent') ?? undefined
+
+  const userData: FbUserData = {
+    ...body.user,
+    fbp: body.fbp,
+    fbc: body.fbc,
+    clientIp,
+    userAgent,
+  }
+
+  await sendFacebookEvent({
+    eventName: body.event,
+    eventId: body.event_id,
+    userData,
+    customData: body.properties,
+    eventSourceUrl: body.url,
+    actionSource: 'website',
+  })
+
+  return NextResponse.json({ ok: true }, { status: 200 })
+}

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -1,6 +1,48 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/app/lib/prisma'
 import { upsertNotealyContact } from '@/app/lib/api/notealy'
+import { sendFacebookEvent } from '@/app/lib/analytics/fb-capi'
+
+// Meta Conversions API — Lead server-side (não depende do pixel do browser).
+// Best-effort: nunca bloqueia o cadastro.
+async function sendLeadToMeta(params: {
+  leadId: string
+  name: string
+  email: string
+  phone: string
+  cpf: string
+  courseName?: string
+  request: NextRequest
+}) {
+  try {
+    const [firstName, ...rest] = params.name.trim().split(/\s+/)
+    const clientIp =
+      params.request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+      params.request.headers.get('x-real-ip') ??
+      undefined
+    await sendFacebookEvent({
+      eventName: 'Lead',
+      eventId: `lead_${params.leadId}`,
+      userData: {
+        email: params.email,
+        phone: params.phone,
+        externalId: params.cpf,
+        firstName: firstName || undefined,
+        lastName: rest.length ? rest.join(' ') : undefined,
+        clientIp,
+        userAgent: params.request.headers.get('user-agent') ?? undefined,
+      },
+      customData: {
+        ...(params.courseName ? { content_name: params.courseName } : {}),
+        content_type: 'product',
+      },
+      actionSource: 'website',
+      eventSourceUrl: params.request.headers.get('referer') ?? undefined,
+    })
+  } catch (error) {
+    console.error('⚠️ Meta CAPI Lead falhou:', error)
+  }
+}
 
 // Estágio 1 do CRM Notealy: cria/atualiza o contato com a tag de lead.
 // Best-effort — nunca bloqueia o cadastro. O email de boas-vindas fica fora
@@ -83,6 +125,16 @@ export async function POST(request: NextRequest) {
         cpf: cleanCpf,
       })
 
+      await sendLeadToMeta({
+        leadId: updatedLead.id,
+        name,
+        email,
+        phone: cleanPhone,
+        cpf: cleanCpf,
+        courseName,
+        request,
+      })
+
       return NextResponse.json({
         lead: updatedLead,
         message: 'Lead updated',
@@ -110,6 +162,16 @@ export async function POST(request: NextRequest) {
       email,
       phone: cleanPhone,
       cpf: cleanCpf,
+    })
+
+    await sendLeadToMeta({
+      leadId: lead.id,
+      name,
+      email,
+      phone: cleanPhone,
+      cpf: cleanCpf,
+      courseName,
+      request,
     })
 
     return NextResponse.json({ lead }, { status: 201 })

--- a/app/checkout/estacio/EstacioCheckoutClient.tsx
+++ b/app/checkout/estacio/EstacioCheckoutClient.tsx
@@ -17,6 +17,7 @@ import {
   User,
 } from 'lucide-react'
 import { usePostHogTracking } from '@/app/lib/hooks/usePostHogTracking'
+import { trackFbqDual } from '@/app/lib/analytics/fbq'
 
 /** Máscaras simples (CPF / telefone / CEP). */
 const maskCpf = (v: string) =>
@@ -246,6 +247,25 @@ export default function EstacioCheckoutClient() {
         numero_inscricao: data?.numeroInscricao ?? undefined,
         already_enrolled: !!data?.alreadyEnrolled,
       })
+
+      // Meta Pixel + Conversions API - Lead (inscrição Estácio; pagamento externo).
+      // event_id pela inscrição quando houver, para dedup/idempotência.
+      void trackFbqDual(
+        'Lead',
+        {
+          content_name: offer.courseName,
+          content_ids: offer.offerId ? [String(offer.offerId)] : undefined,
+          content_type: 'product',
+          currency: 'BRL',
+        },
+        {
+          email: form.email.trim() || undefined,
+          phone: form.mobile.replace(/\D/g, '') || undefined,
+          externalId: form.cpf.replace(/\D/g, '') || undefined,
+          firstName: form.name.trim().split(/\s+/)[0] || undefined,
+        },
+        data?.numeroInscricao ? `estacio_${data.numeroInscricao}` : undefined,
+      )
 
       const params = new URLSearchParams()
       if (offer.courseName) params.set('course', offer.courseName)

--- a/app/checkout/matricula/MatriculaPayment.tsx
+++ b/app/checkout/matricula/MatriculaPayment.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { trackFbqDual } from '@/app/lib/analytics/fbq'
 import {
   BadgeCheck,
   Barcode,
@@ -105,6 +106,31 @@ export default function MatriculaPayment({
     paidRef.current = true
     setPaid(true)
     setPixOpen(false)
+
+    // Meta Pixel + Conversions API - Purchase. eventID = externalId dedupa com
+    // o Purchase server-side disparado em confirmPaidMatricula (mesmo id).
+    const [firstName, ...rest] = (customer.name || '').trim().split(/\s+/)
+    const courseId = typeof metadata?.courseId === 'string' ? metadata.courseId : undefined
+    const courseName = typeof metadata?.courseName === 'string' ? metadata.courseName : description
+    void trackFbqDual(
+      'Purchase',
+      {
+        content_name: courseName,
+        content_ids: courseId ? [courseId] : undefined,
+        content_type: 'product',
+        value: (amountInCents || 0) / 100,
+        currency: 'BRL',
+      },
+      {
+        email: customer.email,
+        phone: customer.phone,
+        externalId: customer.cpf.replace(/\D/g, ''),
+        firstName: firstName || undefined,
+        lastName: rest.length ? rest.join(' ') : undefined,
+      },
+      externalId,
+    )
+
     // Dispara a confirmação server-side (cria inscrição + atualiza CRM).
     // Idempotente: o webhook do gateway/Elysium também cobre (aba fechada).
     if (externalId) {
@@ -119,7 +145,7 @@ export default function MatriculaPayment({
       }
     }
     onPaidRef.current()
-  }, [])
+  }, [amountInCents, customer, description, metadata])
 
   const createCharge = useCallback(
     async (m: Method): Promise<ChargeState | null> => {

--- a/app/checkout/matricula/page.tsx
+++ b/app/checkout/matricula/page.tsx
@@ -40,7 +40,7 @@ import { createMarketplaceInscription } from '@/app/lib/api/create-inscription-m
 import { validateVoucher, type ValidateVoucherResponse, type VoucherInstallment } from '@/app/lib/api/validate-voucher'
 import type { PosPaymentMethod, PosInstallment } from '@/app/lib/api/get-offer-details'
 import { usePostHogTracking } from '@/app/lib/hooks/usePostHogTracking'
-import { trackFbq } from '@/app/lib/analytics/fbq'
+import { trackFbqDual } from '@/app/lib/analytics/fbq'
 import { trackTikTok, trackTikTokDual } from '@/app/lib/analytics/ttq'
 import { readUtmifyParams } from '@/app/lib/analytics/utmify-client'
 import { formatPhone } from '@/utils/formatters'
@@ -412,9 +412,11 @@ const isFormValidForPayment =
         state: offerDetails.unitState,
       })
 
-      // Facebook Pixel - InitiateCheckout
-      trackFbq('InitiateCheckout', {
+      // Facebook Pixel + Conversions API - InitiateCheckout
+      void trackFbqDual('InitiateCheckout', {
         content_name: offerDetails.course,
+        content_ids: offerDetails.courseId ? [String(offerDetails.courseId)] : undefined,
+        content_type: 'product',
         value: offerDetails.subscriptionValue || offerDetails.montlyFeeTo || 0,
         currency: 'BRL',
       })
@@ -1084,12 +1086,22 @@ const isFormValidForPayment =
       course_name: offerDetails.course,
     })
 
-    // Facebook Pixel - CompleteRegistration
-    trackFbq('CompleteRegistration', {
-      content_name: offerDetails.course,
-      value: offerDetails.montlyFeeTo || 0,
-      currency: 'BRL',
-    })
+    // Facebook Pixel + Conversions API - CompleteRegistration (com Advanced Matching)
+    void trackFbqDual(
+      'CompleteRegistration',
+      {
+        content_name: offerDetails.course,
+        content_ids: offerDetails.courseId ? [String(offerDetails.courseId)] : undefined,
+        content_type: 'product',
+        value: offerDetails.montlyFeeTo || 0,
+        currency: 'BRL',
+      },
+      {
+        email: data.email,
+        phone: data.phone,
+        externalId: data.cpf.replace(/\D/g, ''),
+      },
+    )
 
     // TikTok Pixel + Events API - CompleteRegistration (com Advanced Matching)
     void trackTikTokDual(
@@ -1593,12 +1605,22 @@ const isFormValidForPayment =
                                         course_name: offerDetails?.course,
                                       })
 
-                                      // Facebook Pixel - AddPaymentInfo (dados pessoais preenchidos + CPF validado)
-                                      trackFbq('AddPaymentInfo', {
-                                        content_name: offerDetails?.course,
-                                        value: offerDetails?.subscriptionValue || offerDetails?.montlyFeeTo || 0,
-                                        currency: 'BRL',
-                                      })
+                                      // Facebook Pixel + Conversions API - AddPaymentInfo (dados pessoais preenchidos + CPF validado)
+                                      void trackFbqDual(
+                                        'AddPaymentInfo',
+                                        {
+                                          content_name: offerDetails?.course,
+                                          content_ids: offerDetails?.courseId ? [String(offerDetails.courseId)] : undefined,
+                                          content_type: 'product',
+                                          value: offerDetails?.subscriptionValue || offerDetails?.montlyFeeTo || 0,
+                                          currency: 'BRL',
+                                        },
+                                        {
+                                          email: getValues('email') || undefined,
+                                          phone: getValues('phone') || undefined,
+                                          externalId: (getValues('cpf') || '').replace(/\D/g, '') || undefined,
+                                        },
+                                      )
 
                                       // TikTok Pixel - AddPaymentInfo
                                       trackTikTok('AddPaymentInfo', {

--- a/app/checkout/matricula/sucesso/MatriculaSuccessClient.tsx
+++ b/app/checkout/matricula/sucesso/MatriculaSuccessClient.tsx
@@ -6,7 +6,6 @@ import { useSearchParams } from 'next/navigation'
 import { CheckCircle2, ExternalLink } from 'lucide-react'
 import { formatCurrency } from '@/utils/fomartCurrency'
 import { usePostHogTracking } from '@/app/lib/hooks/usePostHogTracking'
-import { trackFbq } from '@/app/lib/analytics/fbq'
 import { trackTikTokDual } from '@/app/lib/analytics/ttq'
 
 export default function MatriculaSuccessClient() {
@@ -45,12 +44,9 @@ export default function MatriculaSuccessClient() {
       w.dataLayer = w.dataLayer ?? [];
       w.dataLayer.push({ event: eventName });
 
-      // Facebook Pixel - Lead (inscrição realizada, pagamento será na universidade)
-      trackFbq('Lead', {
-        content_name: course || undefined,
-        value: monthlyFee ?? 0,
-        currency: 'BRL',
-      })
+      // Meta Lead/Purchase NÃO são disparados aqui: o Lead vai server-side em
+      // /api/leads (PII completa, confiável) e o Purchase em confirmPaid +
+      // confirmPaidMatricula. Disparar aqui duplicaria a conversão.
 
       // TikTok Pixel + Events API - SubmitForm (conversão final, inscrição confirmada)
       void trackTikTokDual('SubmitForm', {

--- a/app/components/CourseCardNew/index.tsx
+++ b/app/components/CourseCardNew/index.tsx
@@ -3,7 +3,7 @@ import { Course } from "@/app/interface/course"
 import { postSearch } from "@/app/lib/api/post-search"
 import { useFavorites } from "@/app/lib/hooks/useFavorites"
 import { usePostHogTracking } from "@/app/lib/hooks/usePostHogTracking"
-import { trackFbq } from "@/app/lib/analytics/fbq"
+import { trackFbqDual } from "@/app/lib/analytics/fbq"
 import { trackTikTok } from "@/app/lib/analytics/ttq"
 import { getAcademicLevelLabel } from "@/app/lib/academic-level"
 import { Building2, Clock, Heart, MapPin, Star } from "lucide-react"
@@ -157,10 +157,11 @@ const CourseCardNew: React.FC<CourseCardProps> = ({
       is_favorite: isFavorite(course),
     })
 
-    // Facebook Pixel - ViewContent (curso selecionado)
-    trackFbq('ViewContent', {
+    // Facebook Pixel + Conversions API - ViewContent (curso selecionado)
+    void trackFbqDual('ViewContent', {
       content_name: course.name,
       content_type: 'product',
+      content_ids: course.id ? [String(course.id)] : undefined,
       value: course.minPrice || 0,
       currency: 'BRL',
     })

--- a/app/lib/analytics/fb-capi.ts
+++ b/app/lib/analytics/fb-capi.ts
@@ -1,0 +1,125 @@
+import { normalizeEmail, normalizePhone, sha256 } from './hash'
+
+/**
+ * Conversions API (server-side) do Meta. Espelha o que /api/tiktok/event faz
+ * para o TikTok: envia o evento direto para o Graph API, com advanced matching
+ * (email/telefone/CPF hasheados em SHA-256) + fbp/fbc/ip/user_agent. Garante que
+ * conversões cheguem ao Events Manager mesmo com ad-blocker, ITP ou aba fechada.
+ *
+ * Dedup com o pixel do browser: usar o MESMO `eventId` nos dois lados.
+ */
+
+const GRAPH_VERSION = 'v21.0'
+
+export interface FbUserData {
+  email?: string
+  phone?: string
+  /** CPF (só dígitos) → external_id */
+  externalId?: string
+  firstName?: string
+  lastName?: string
+  city?: string
+  state?: string
+  /** Cookie _fbp do browser (não hasheado) */
+  fbp?: string
+  /** Cookie _fbc do browser (não hasheado) */
+  fbc?: string
+  clientIp?: string
+  userAgent?: string
+}
+
+export interface SendFacebookEventInput {
+  eventName: string
+  eventId: string
+  /** Unix em segundos. Default: agora. */
+  eventTime?: number
+  userData: FbUserData
+  customData?: Record<string, unknown>
+  eventSourceUrl?: string
+  /** Default 'website'. Use 'system_generated' para eventos puramente server. */
+  actionSource?: 'website' | 'app' | 'system_generated' | 'other'
+}
+
+function pixelIds(): string[] {
+  const raw = process.env.NEXT_PUBLIC_FB_PIXEL_IDS
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean)
+}
+
+async function buildUserData(u: FbUserData): Promise<Record<string, unknown>> {
+  const data: Record<string, unknown> = {}
+  if (u.email) data.em = [await sha256(normalizeEmail(u.email))]
+  if (u.phone) data.ph = [await sha256(normalizePhone(u.phone))]
+  if (u.externalId) data.external_id = [await sha256(u.externalId.replace(/\D/g, ''))]
+  if (u.firstName) data.fn = [await sha256(u.firstName.trim().toLowerCase())]
+  if (u.lastName) data.ln = [await sha256(u.lastName.trim().toLowerCase())]
+  if (u.city) data.ct = [await sha256(u.city.trim().toLowerCase().replace(/\s/g, ''))]
+  if (u.state) data.st = [await sha256(u.state.trim().toLowerCase().replace(/\s/g, ''))]
+  // Não hasheados:
+  if (u.fbp) data.fbp = u.fbp
+  if (u.fbc) data.fbc = u.fbc
+  if (u.clientIp) data.client_ip_address = u.clientIp
+  if (u.userAgent) data.client_user_agent = u.userAgent
+  return data
+}
+
+/**
+ * Best-effort: nunca lança. Loga e segue, igual ao route do TikTok.
+ * Envia para TODOS os pixels configurados em NEXT_PUBLIC_FB_PIXEL_IDS.
+ */
+export async function sendFacebookEvent(input: SendFacebookEventInput): Promise<void> {
+  const accessToken = process.env.FB_CONVERSIONS_ACCESS_TOKEN
+  const ids = pixelIds()
+  if (!accessToken || ids.length === 0) {
+    if (!accessToken) console.warn('[fb-capi] FB_CONVERSIONS_ACCESS_TOKEN ausente — pulando')
+    return
+  }
+
+  const userData = await buildUserData(input.userData)
+  const testEventCode = process.env.FB_TEST_EVENT_CODE || undefined
+
+  const eventPayload = {
+    event_name: input.eventName,
+    event_time: input.eventTime ?? Math.floor(Date.now() / 1000),
+    event_id: input.eventId,
+    action_source: input.actionSource ?? 'website',
+    ...(input.eventSourceUrl ? { event_source_url: input.eventSourceUrl } : {}),
+    user_data: userData,
+    ...(input.customData ? { custom_data: input.customData } : {}),
+  }
+
+  await Promise.all(
+    ids.map(async (pixelId) => {
+      try {
+        const res = await fetch(
+          `https://graph.facebook.com/${GRAPH_VERSION}/${pixelId}/events`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              data: [eventPayload],
+              access_token: accessToken,
+              ...(testEventCode ? { test_event_code: testEventCode } : {}),
+            }),
+          }
+        )
+        if (!res.ok) {
+          const text = await res.text().catch(() => '')
+          console.error('[fb-capi] http error', pixelId, res.status, text)
+          return
+        }
+        const json = (await res.json().catch(() => ({}))) as {
+          error?: { message?: string }
+        }
+        if (json.error) {
+          console.error('[fb-capi] api error', pixelId, json.error.message)
+        }
+      } catch (err) {
+        console.error('[fb-capi] fetch failed', pixelId, err)
+      }
+    })
+  )
+}

--- a/app/lib/analytics/fbq.ts
+++ b/app/lib/analytics/fbq.ts
@@ -1,9 +1,38 @@
+import { readConsent } from '@/app/lib/consent/storage'
+
 type FbqFn = (...args: unknown[]) => void
 
 function getFbq(): FbqFn | null {
   if (typeof window === 'undefined') return null
   const fbq = (window as unknown as Record<string, unknown>).fbq
   return typeof fbq === 'function' ? (fbq as FbqFn) : null
+}
+
+function readCookie(name: string): string | undefined {
+  if (typeof document === 'undefined') return undefined
+  const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'))
+  return match ? decodeURIComponent(match[1]) : undefined
+}
+
+function marketingAllowed(): boolean {
+  return readConsent()?.categories.marketing === true
+}
+
+function newEventId(): string {
+  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+export interface FbqUser {
+  email?: string
+  phone?: string
+  /** CPF (só dígitos) → external_id */
+  externalId?: string
+  firstName?: string
+  lastName?: string
+  city?: string
+  state?: string
 }
 
 export function trackFbq(eventName: string, data?: Record<string, unknown>): void {
@@ -29,6 +58,57 @@ export function trackFbqCustom(eventName: string, data?: Record<string, unknown>
     } else {
       fbq('trackCustom', eventName)
     }
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Dispara o evento no pixel do browser E na Conversions API (server), com o
+ * MESMO event_id para deduplicação. Espelha trackTikTokDual. O envio server
+ * garante a entrega mesmo com ad-blocker/ITP, e o advanced matching (user)
+ * eleva o EMQ. Tudo gateado pelo consentimento de marketing (paridade LGPD).
+ *
+ * Passe `eventId` explícito quando precisar casar com um id server-side
+ * conhecido (ex.: Purchase usa externalTransactionId nos dois lados).
+ */
+export async function trackFbqDual(
+  eventName: string,
+  data?: Record<string, unknown>,
+  user?: FbqUser,
+  eventId?: string,
+): Promise<void> {
+  if (!marketingAllowed()) return
+
+  const id = eventId ?? newEventId()
+
+  // 1) Pixel do browser, com eventID para dedup.
+  const fbq = getFbq()
+  if (fbq) {
+    try {
+      fbq('track', eventName, data ?? {}, { eventID: id })
+    } catch {
+      // Pixel internal error — segue para o server.
+    }
+  }
+
+  // 2) Conversions API (server).
+  try {
+    fetch('/api/facebook/event', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      keepalive: true,
+      body: JSON.stringify({
+        event: eventName,
+        event_id: id,
+        properties: data,
+        user,
+        url: typeof window !== 'undefined' ? window.location.href : undefined,
+        referrer: typeof document !== 'undefined' ? document.referrer : undefined,
+        fbp: readCookie('_fbp'),
+        fbc: readCookie('_fbc'),
+      }),
+    }).catch(() => {})
   } catch {
     // ignore
   }

--- a/app/lib/checkout/confirm-matricula.ts
+++ b/app/lib/checkout/confirm-matricula.ts
@@ -8,6 +8,7 @@ import {
 import type { OfferDetails } from '@/app/lib/api/get-offer-details'
 import { upsertNotealyContact } from '@/app/lib/api/notealy'
 import { sendUtmifyOrder, paymentMethodToUtmify } from '@/app/lib/api/utmify'
+import { sendFacebookEvent } from '@/app/lib/analytics/fb-capi'
 
 /**
  * Dados montados no checkout (cliente) e guardados em Transaction.metadata.confirm
@@ -166,6 +167,33 @@ export async function confirmPaidMatricula(
     })
   } catch (e) {
     console.error('❌ confirm: UTMify falhou', externalTransactionId, e)
+  }
+
+  // 4) Meta Conversions API — Purchase server-side (chega mesmo com aba fechada).
+  // event_id = externalTransactionId dedupa com o Purchase do pixel na página
+  // de sucesso (que usa o mesmo id).
+  try {
+    const [firstName, ...rest] = tx.name.trim().split(/\s+/)
+    await sendFacebookEvent({
+      eventName: 'Purchase',
+      eventId: externalTransactionId,
+      userData: {
+        email: tx.email,
+        phone: phoneDigits,
+        externalId: cpfDigits,
+        firstName: firstName || undefined,
+        lastName: rest.length ? rest.join(' ') : undefined,
+      },
+      customData: {
+        currency: 'BRL',
+        value: tx.amountInCents / 100,
+        content_name: tx.courseName || 'Matrícula',
+        content_type: 'product',
+        ...(tx.courseId ? { content_ids: [tx.courseId] } : {}),
+      },
+    })
+  } catch (e) {
+    console.error('❌ confirm: Meta CAPI Purchase falhou', externalTransactionId, e)
   }
 
   // Persistir resultados (best-effort) para auditoria.

--- a/env.example
+++ b/env.example
@@ -65,6 +65,18 @@ TURNSTILE_SECRET_KEY=
 # Sem OPENAI_API_KEY o /teste-vocacional não funciona
 OPENAI_API_KEY=
 
+# Meta Pixel (Events Manager → Data Sources). Aceita múltiplos IDs separados por vírgula.
+# Sem NEXT_PUBLIC_FB_PIXEL_IDS o pixel não carrega (no-op).
+NEXT_PUBLIC_FB_PIXEL_IDS=
+
+# Meta Conversions API (Events Manager → Settings → Conversions API → Generate Access Token)
+# Server-side: garante a entrega das conversões mesmo com ad-blocker/ITP/aba fechada.
+# Dedup com o pixel é pelo event_id. Sem FB_CONVERSIONS_ACCESS_TOKEN o /api/facebook/event
+# e os envios server-side (Purchase/Lead) ficam no-op.
+FB_CONVERSIONS_ACCESS_TOKEN=
+# Opcional: cole o code de "Test Events" para validar sem poluir o dataset de produção.
+FB_TEST_EVENT_CODE=
+
 # TikTok Pixel (criar em ads.tiktok.com → Tools → Events Manager → Web → Manually Set Up)
 # Sem NEXT_PUBLIC_TIKTOK_PIXEL_ID o pixel não carrega (no-op)
 NEXT_PUBLIC_TIKTOK_PIXEL_ID=


### PR DESCRIPTION
## Problema

Conversões não chegavam ao Events Manager. Confirmado com dados reais da Meta (últimos 7 dias): os dois pixels recebiam **só eventos `BROWSER`**, e na prática só `PageView`/`ViewContent`. `Lead`/`Purchase`/`InitiateCheckout`/`AddPaymentInfo`/`CompleteRegistration` disparavam fundo no checkout, em volta de navegações full-page e redirects para o pagamento, onde o pixel (`lazyOnload` + gateado por consent opt-in) ainda não tinha carregado → `trackFbq` fazia no-op silencioso. Ad-blocker + ITP do Safari fechavam a conta. O `/checkout/success` legado (que disparava `Purchase`) **nunca é roteado**.

## Solução — Conversions API server-side

Espelha o padrão já existente no repo para TikTok (`trackTikTokDual` + `/api/tiktok/event`) e UTMify (order pago em `confirmPaidMatricula`).

- **`app/lib/analytics/fb-capi.ts`** (novo): util server-side — hash SHA-256 de `em`/`ph`/`external_id`/`fn`/`ln`, `fbp`/`fbc`/`ip`/`user_agent`, loop sobre todos os pixels de `NEXT_PUBLIC_FB_PIXEL_IDS`.
- **`app/api/facebook/event/route.ts`** (novo): route client→server (IP/UA dos headers).
- **`trackFbqDual`** em `fbq.ts`: pixel + CAPI com o mesmo `event_id` (dedup) e advanced matching, gateado pelo consent de marketing.
- **`Purchase`** server-side em `confirmPaidMatricula` (idempotente, chega com aba fechada/boleto), `event_id = externalTransactionId`; o client (`confirmPaid`) usa o mesmo id → dedup.
- **`Lead`** server-side em `/api/leads` (PII completa, cobre todos os pontos de captação).
- `ViewContent`/`InitiateCheckout`/`AddPaymentInfo`/`CompleteRegistration` → `trackFbqDual` com advanced matching.
- **`Lead`** na inscrição Estácio (antes não disparava nada) + evento **`Search`**.
- Remove `Lead` client redundante do success page (server já cobre) para evitar double-counting.

## Env (ação necessária)

Setar **`FB_CONVERSIONS_ACCESS_TOKEN`** (Events Manager → Settings → Conversions API → Generate Access Token) no `.env` local **e na env de produção (Vercel)**. Sem ela, todo o lado server-side fica no-op. `FB_TEST_EVENT_CODE` opcional para validar via Test Events. Documentados em `env.example`. **Não** prefixar com `NEXT_PUBLIC_` (segredo de servidor).

## Verificação

- `tsc --noEmit` limpo; lint sem erros.
- Com `FB_TEST_EVENT_CODE`: percorrer o funil e confirmar cada evento com **Server + Browser** e **Deduplicated**.
- Pós-deploy: conferir via Meta que `event_source` `SERVER > 0` para `Purchase`/`Lead`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)