### PR TITLE
fix(seo): home title duplicava a marca + description longa demais

### DIFF
--- a/app/(default)/page.tsx
+++ b/app/(default)/page.tsx
@@ -28,11 +28,13 @@ const theme = getCurrentTheme()
 // "marketplace" fica no corpo/FAQ/llms.txt (diferencial + classificação por IA),
 // não no início do title (zero volume de busca).
 export const metadata: Metadata = {
+  // `absolute` ignora o title.template do layout pai (a home é folha, não tem
+  // rotas filhas). Sem isso, "%s | Bolsa Click" era colado por cima de um valor
+  // que já terminava em "Bolsa Click" → marca duplicada no <title>.
   title: {
-    default: 'Bolsas de Estudo de até 80% em 30.000+ Faculdades | Bolsa Click',
-    template: `%s | ${theme.shortTitle}`,
+    absolute: 'Bolsas de Estudo de até 80% em 30.000+ Faculdades | Bolsa Click',
   },
-  description: 'Compare e garanta bolsa de estudo de até 80% em 100.000+ cursos de faculdades parceiras reconhecidas pelo MEC — Anhanguera, Unopar, Pitágoras e outras. Marketplace independente, inscrição grátis, EAD ou presencial.',
+  description: 'Compare e garanta bolsa de estudo de até 80% em faculdades reconhecidas pelo MEC — Anhanguera, Unopar, Pitágoras e outras. Inscrição grátis, EAD ou presencial.',
   keywords: [
     'bolsa de estudo',
     'bolsa de estudos',


### PR DESCRIPTION
## Problema (verificado no HTML ao vivo via curl)

1. **Title duplicava a marca.** O `<title>` da home renderizava como:
   `Bolsas de Estudo de até 80% em 30.000+ Faculdades | Bolsa Click | Bolsa Click`
   O `title.template` (`%s | Bolsa Click`) do layout era colado por cima de um `title.default` que já terminava em "Bolsa Click". Desperdiçava ~14 chars e parecia spam no SERP.

2. **Description com 214 chars** — excedia o limite de exibição do Google (~155-160), o final era cortado no resultado.

## Correção (`app/(default)/page.tsx`)

- `title` → `title: { absolute: '...' }`, que ignora o template do layout pai (a home é folha, não tem rotas filhas). Marca passa a aparecer **uma vez só** (63 chars). O `template` legítimo continua no `app/layout.tsx` para as páginas filhas.
- `description` → reduzida para **159 chars**, mantendo "bolsa de estudo de até 80%" no início e os parceiros (whitelist do CLAUDE.md).

## Não-issue
**X-Robots-Tag "Missing"** não era problema: é header HTTP opcional que duplica o `<meta name="robots" content="index, follow">` já presente. Página segue 100% indexável. Nenhuma mudança.

## Verificação
- `tsc --noEmit` limpo.
- Pós-deploy: `curl -s https://www.bolsaclick.com.br/ | grep '<title>'` → marca uma vez só. Depois pedir reindexação no Search Console (SERP leva dias para refletir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)