### PR TITLE
fix(seo): cortar flood de crawl budget nas páginas curso×cidade

### DIFF
--- a/app/lib/seo/city-page-gate.ts
+++ b/app/lib/seo/city-page-gate.ts
@@ -24,10 +24,11 @@ export function shouldIndexCityPage(
   // Oferta local suficiente → index (comparativo tem valor SEO)
   if (offerCount >= MIN_OFFERS_TO_INDEX) return true
 
-  // Sem oferta local (ou só 1) MAS demanda alta → index assim mesmo, o conteúdo
-  // de curso + FAQ + contexto da cidade rankeia pela intenção informacional.
-  // Threshold mais alto (≥ 60) pra compensar a falta de oferta concreta.
-  if ((trendScore ?? 0) >= 60) return true
+  // Demanda alta (≥ 60) MAS ainda exige ao menos 1 oferta local: sem nenhuma
+  // oferta, a página é duplicata do conteúdo nacional + nome da cidade — thin em
+  // escala que afoga o crawl budget (Google joga pra "Detectada, não indexada").
+  // Com ≥ 1 oferta + alta demanda, o comparativo local tem substância pra rankear.
+  if ((trendScore ?? 0) >= 60 && offerCount >= 1) return true
 
   return false
 }

--- a/app/sitemap/[id]/route.ts
+++ b/app/sitemap/[id]/route.ts
@@ -57,11 +57,15 @@ function cityCoursePriority(trendScore: number, citySlug: string): number {
   return Math.round((0.30 + trendNorm * 0.35 + tierBonus) * 100) / 100
 }
 
+// Fallback p/ cursos SEM cache de oferta auditado (raro após threshold=5).
+// Sem dado de oferta, ser conservador: não emitir tier-1 incondicional (era a
+// 2ª fonte do flood). Só emite cidade de topo com demanda mínima; resto espera
+// o precompute popular o cache e cair no branch ciente de oferta.
 function shouldEmitCityUrl(trendScore: number, citySlug: string): boolean {
   const tier = cityTier(citySlug)
-  if (tier === 1) return true
-  if (tier === 2) return trendScore >= 30
-  return trendScore >= 60
+  if (tier === 1) return trendScore >= 30
+  if (tier === 2) return trendScore >= 60
+  return false
 }
 
 async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
@@ -153,8 +157,10 @@ async function buildCoursesSitemap(): Promise<SitemapEntry[]> {
 
 async function buildCourseCitiesSitemap(): Promise<SitemapEntry[]> {
   // Threshold mínimo de cache populado por curso pra considerá-lo "auditado".
-  // Abaixo disso, caímos no filtro só por tier+trendScore (mesmo do passado).
-  const CACHE_AUDITED_THRESHOLD = 20
+  // Abaixo disso, cai no fallback conservador (shouldEmitCityUrl). Baixado de
+  // 20 → 5 pra que ~todos os cursos (cache ~61 cidades/curso) usem o branch
+  // ciente de oferta em vez do fallback, cortando o flood de URLs sem oferta.
+  const CACHE_AUDITED_THRESHOLD = 5
 
   try {
     const [courses, cacheRows] = await withTimeout(
@@ -198,14 +204,15 @@ async function buildCourseCitiesSitemap(): Promise<SitemapEntry[]> {
             // Sem cache auditado pro curso → mantém comportamento legado.
             if (!isAudited) return shouldEmitCityUrl(score, city.slug)
 
-            // Com cache auditado: aplica o mesmo critério do
-            // shouldIndexCityPage (gate runtime) — emitir só se vale indexar.
+            // Com cache auditado: aplica o MESMO critério do shouldIndexCityPage
+            // (gate runtime) — emitir só o que é indexável, nunca URL noindex.
             //   offerCount ≥ 2 → emit
-            //   offerCount 0-1 + trendScore ≥ 60 → emit (ranking informacional)
-            //   caso contrário → skip (não polui sitemap com URL noindex).
+            //   offerCount = 1 + trendScore ≥ 60 → emit (alta demanda + alguma oferta)
+            //   offerCount = 0 → skip SEMPRE (era a fonte do flood: trend≥60 emitia
+            //                    todas as cidades de curso popular sem oferta local).
             const offers = courseCache!.get(city.slug) ?? 0
             if (offers >= 2) return true
-            if (score >= 60) return true
+            if (score >= 60 && offers >= 1) return true
             return false
           })
           .map((city) => ({


### PR DESCRIPTION
## Contexto

GSC mostrava **27,9 mil URLs em "Detectada, mas não indexada"** (Discovered – currently not indexed). Diagnóstico: o branch `trendScore >= 60` do gate emitia **todas** as cidades de um curso popular no sitemap, mesmo sem oferta local — `trendScore` é nacional por curso. Resultado: ~25k páginas curso×cidade quase-duplicadas afogando o crawl budget, segurando até as ~5,9k páginas com oferta real e posts de blog.

## Mudanças

- **`app/lib/seo/city-page-gate.ts`** — branch de alta demanda agora exige `trendScore >= 60 && offerCount >= 1`. Páginas com zero oferta viram `noindex,follow` + canonical nacional.
- **`app/sitemap/[id]/route.ts`** — emissão do sitemap 2 alinhada ao gate (nunca emite `offerCount == 0`); `CACHE_AUDITED_THRESHOLD` 20→5 (roteia ~todos os 177 cursos pro branch ciente de oferta); fallback `shouldEmitCityUrl` conservador (não emite tier-1 sem demanda).

## Impacto medido (contra o cache atual)

| | URLs curso×cidade no sitemap |
|---|---|
| Antes | 25.104 |
| Depois | 6.591 |
| **Redução** | **18.513 (-74%)** |

## Segurança

As páginas que viram `noindex` são exatamente as zero-oferta que estavam em "Detectada, não indexada" — **não estavam indexadas, não traziam clique orgânico**. Nada que rankeia é afetado. `tsc` limpo; truth table do gate validada (`(2,0)→idx`, `(0,90)→noidx`, `(1,90)→idx`, `(0,10)→noidx`).

## Pós-merge (GSC, manual)
Reenviar sitemaps + Solicitar indexação no post de blog preso; monitorar a queda de "Detectada, não indexada" por 2-4 semanas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)