### PR TITLE
fix(seo): home description abaixo de 155 chars e com voz mais natural

### DIFF
--- a/app/(default)/page.tsx
+++ b/app/(default)/page.tsx
@@ -34,7 +34,7 @@ export const metadata: Metadata = {
   title: {
     absolute: 'Bolsas de Estudo de até 80% em 30.000+ Faculdades | Bolsa Click',
   },
-  description: 'Compare e garanta bolsa de estudo de até 80% em faculdades reconhecidas pelo MEC — Anhanguera, Unopar, Pitágoras e outras. Inscrição grátis, EAD ou presencial.',
+  description: 'Bolsa de estudo de até 80% em faculdades como Anhanguera, Unopar e Pitágoras, todas reconhecidas pelo MEC. Inscrição grátis, no EAD ou presencial.',
   keywords: [
     'bolsa de estudo',
     'bolsa de estudos',


### PR DESCRIPTION
Description da home estava com 159 chars (acima do limite) e com padrão de texto gerado por IA: imperativo duplo "Compare e garanta", travessão listando marcas e "e outras". Reescrita pra 146 chars mantendo head-term, "até 80%", as 3 marcas parceiras, MEC e modalidades.