### PR TITLE
fix(seo): escapar aspas no texto JSX dos hubs de intenção

### DIFF
--- a/app/(default)/bolsa-de-estudo-e-gratis/page.tsx
+++ b/app/(default)/bolsa-de-estudo-e-gratis/page.tsx
@@ -97,7 +97,7 @@ export default function BolsaDeEstudoEGratis() {
             <strong>Buscar bolsa de estudo não deve custar taxa.</strong> Plataformas sérias são
             gratuitas para o aluno: você compara as ofertas sem pagar nada. No Bolsa Click o cadastro
             é 100% grátis e o único valor que você paga é a mensalidade — já com o desconto da bolsa —
-            direto à faculdade, nunca à plataforma. Qualquer cobrança antecipada para "liberar" uma
+            direto à faculdade, nunca à plataforma. Qualquer cobrança antecipada para “liberar” uma
             bolsa é sinal de golpe.
           </p>
         </div>
@@ -113,7 +113,7 @@ export default function BolsaDeEstudoEGratis() {
             compra. Por isso, a busca e a comparação de ofertas devem ser gratuitas. As plataformas
             que reúnem bolsas são remuneradas pelas próprias faculdades quando o aluno se matricula —
             o estudante não entra nessa conta. Se algum site, perfil ou pessoa pede pagamento para
-            "garantir", "reservar" ou "liberar" a bolsa antes da matrícula, trate como alerta: numa
+            “garantir”, “reservar” ou “liberar” a bolsa antes da matrícula, trate como alerta: numa
             operação legítima esse tipo de cobrança não existe.
           </p>
         </div>

--- a/app/(default)/como-saber-se-um-site-de-bolsa-e-confiavel/page.tsx
+++ b/app/(default)/como-saber-se-um-site-de-bolsa-e-confiavel/page.tsx
@@ -95,7 +95,7 @@ export default function ComoSaberSeUmSiteDeBolsaEConfiavel() {
             Um site de bolsa de estudo é confiável quando <strong>não cobra taxa do aluno, mostra o
             preço antes do cadastro, trabalha com faculdades reconhecidas pelo MEC e o pagamento vai
             direto à instituição</strong> — nunca à plataforma. Se pedirem dinheiro antecipado para
-            "liberar" a bolsa, é golpe. Veja o checklist completo abaixo.
+            “liberar” a bolsa, é golpe. Veja o checklist completo abaixo.
           </p>
         </div>
       </section>
@@ -110,7 +110,7 @@ export default function ComoSaberSeUmSiteDeBolsaEConfiavel() {
             <li><strong>Preço visível antes do cadastro</strong> — você vê o desconto e o valor da mensalidade sem compromisso.</li>
             <li><strong>Faculdades reconhecidas pelo MEC</strong> — dá para conferir cada instituição no portal e-MEC.</li>
             <li><strong>Pagamento direto à faculdade</strong> — a mensalidade vai à instituição, nunca à plataforma ou a uma conta pessoal.</li>
-            <li><strong>Sem cobrança antecipada</strong> — nada de pagar para "reservar" ou "liberar" a bolsa antes da matrícula.</li>
+            <li><strong>Sem cobrança antecipada</strong> — nada de pagar para “reservar” ou “liberar” a bolsa antes da matrícula.</li>
           </ul>
         </div>
       </section>
@@ -122,7 +122,7 @@ export default function ComoSaberSeUmSiteDeBolsaEConfiavel() {
           </h2>
           <p className="text-ink-700 leading-relaxed">
             O golpe quase sempre começa por uma cobrança que não deveria existir: uma taxa para
-            "garantir a vaga", um depósito em conta de pessoa física, ou um valor para "destravar" a
+            “garantir a vaga”, um depósito em conta de pessoa física, ou um valor para “destravar” a
             bolsa. Plataformas legítimas não cobram o aluno antes da matrícula — elas são remuneradas
             pelas faculdades. Outro alerta é a falta de transparência: se o nome da faculdade, o
             reconhecimento pelo MEC ou o preço só aparecem depois de muita insistência, desconfie.


### PR DESCRIPTION
## Problema
`next build` falhava em `react/no-unescaped-entities` por aspas retas (`"`) no texto JSX dos hubs de intenção (`/bolsa-de-estudo-e-gratis` e `/como-saber-se-um-site-de-bolsa-e-confiavel`).

## Fix
Aspas retas → tipográficas (`“ ”`) no texto visível. Melhor display em PT-BR e sem lint error. As strings JS do array `FAQ` não eram afetadas (não são JSX text). `como-funciona-bolsa-de-estudo` já estava limpo.

Validado com `npx eslint` nos 3 hubs (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)