### PR TITLE
feat(ingressa): landings de conversão dos parceiros (ingressa.digital)

### DIFF
--- a/app/api/ingressa/route.ts
+++ b/app/api/ingressa/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/app/lib/prisma'
+import { upsertNotealyContact } from '@/app/lib/api/notealy'
+import { sendFacebookEvent } from '@/app/lib/analytics/fb-capi'
+
+interface IngressaBody {
+  name: string
+  phone: string
+  partner?: string
+  partnerName?: string
+  curso?: string | null
+  utm?: Record<string, string>
+}
+
+// Rate-limit por IP (mesmo padrão do simulador/teste vocacional).
+const submitsByIp = new Map<string, { count: number; resetAt: number }>()
+const SUBMIT_WINDOW_MS = 24 * 60 * 60 * 1000
+const SUBMIT_MAX = 20
+
+function checkSubmitLimit(ip: string): boolean {
+  const now = Date.now()
+  const entry = submitsByIp.get(ip)
+  if (!entry || entry.resetAt < now) {
+    submitsByIp.set(ip, { count: 1, resetAt: now + SUBMIT_WINDOW_MS })
+    return true
+  }
+  if (entry.count >= SUBMIT_MAX) return false
+  entry.count += 1
+  return true
+}
+
+async function sendLeadToMeta(params: {
+  leadId: string
+  name: string
+  phone: string
+  partner?: string
+  request: NextRequest
+}) {
+  try {
+    const [firstName, ...rest] = params.name.trim().split(/\s+/)
+    const clientIp =
+      params.request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+      params.request.headers.get('x-real-ip') ??
+      undefined
+    await sendFacebookEvent({
+      eventName: 'Lead',
+      eventId: `ingressa_${params.leadId}`,
+      userData: {
+        phone: params.phone,
+        firstName: firstName || undefined,
+        lastName: rest.length ? rest.join(' ') : undefined,
+        clientIp,
+        userAgent: params.request.headers.get('user-agent') ?? undefined,
+      },
+      customData: {
+        ...(params.partner ? { content_name: params.partner } : {}),
+        content_category: 'ingressa-landing',
+        content_type: 'product',
+      },
+      actionSource: 'website',
+      eventSourceUrl: params.request.headers.get('referer') ?? undefined,
+    })
+  } catch (error) {
+    console.error('⚠️ Meta CAPI Lead (ingressa) falhou:', error)
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+  if (!checkSubmitLimit(ip)) {
+    return NextResponse.json({ error: 'Limite diário atingido. Tente amanhã.' }, { status: 429 })
+  }
+
+  let body: IngressaBody
+  try {
+    body = (await request.json()) as IngressaBody
+  } catch {
+    return NextResponse.json({ error: 'Body inválido' }, { status: 400 })
+  }
+
+  const { name, phone, partner, curso } = body
+  if (!name?.trim() || name.trim().length < 2) {
+    return NextResponse.json({ error: 'Nome inválido' }, { status: 400 })
+  }
+  const cleanPhone = phone?.replace(/\D/g, '') ?? ''
+  if (cleanPhone.length < 10 || cleanPhone.length > 11) {
+    return NextResponse.json({ error: 'Telefone inválido' }, { status: 400 })
+  }
+
+  const cleanName = name.trim().slice(0, 80)
+  const partnerSlug = typeof partner === 'string' ? partner.slice(0, 40) : 'desconhecido'
+  const cursoName = typeof curso === 'string' && curso.trim() ? curso.trim() : undefined
+
+  // 1) Persistir Lead (email vazio: landing de mídia paga captura só nome+WhatsApp).
+  let leadId = ''
+  try {
+    const lead = await prisma.lead.create({
+      data: {
+        name: cleanName,
+        email: '',
+        phone: cleanPhone,
+        courseNames: cursoName ? [cursoName] : [],
+        courseName: cursoName,
+        institutionName: typeof body.partnerName === 'string' ? body.partnerName : undefined,
+        source: `ingressa-${partnerSlug}`,
+        extraData: JSON.parse(
+          JSON.stringify({ partner: partnerSlug, curso: cursoName, utm: body.utm ?? {} })
+        ),
+        status: 'NEW',
+      },
+    })
+    leadId = lead.id
+  } catch (error) {
+    console.error('Falha ao criar Lead (ingressa):', error)
+  }
+
+  // 2) Notealy (best-effort).
+  try {
+    await upsertNotealyContact({
+      name: cleanName,
+      phone: cleanPhone,
+      tagId: process.env.NOTEALY_TAG_INGRESSA ?? process.env.NOTEALY_TAG_LEAD,
+    })
+  } catch (error) {
+    console.error('⚠️ Notealy (ingressa) falhou:', error)
+  }
+
+  // 3) Meta CAPI (best-effort).
+  if (leadId) {
+    await sendLeadToMeta({ leadId, name: cleanName, phone: cleanPhone, partner: partnerSlug, request })
+  }
+
+  return NextResponse.json({ ok: true }, { status: 201 })
+}

--- a/app/lp/[partner]/_components/LeadForm.tsx
+++ b/app/lp/[partner]/_components/LeadForm.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { CheckCircle2, Loader2 } from 'lucide-react'
+
+interface LeadFormProps {
+  partner: string
+  partnerName: string
+  courses: string[]
+}
+
+function formatPhone(value: string): string {
+  const d = value.replace(/\D/g, '').slice(0, 11)
+  if (d.length <= 2) return d
+  if (d.length <= 6) return `(${d.slice(0, 2)}) ${d.slice(2)}`
+  if (d.length <= 10) return `(${d.slice(0, 2)}) ${d.slice(2, 6)}-${d.slice(6)}`
+  return `(${d.slice(0, 2)}) ${d.slice(2, 7)}-${d.slice(7)}`
+}
+
+const UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'fbclid']
+
+export function LeadForm({ partner, partnerName, courses }: LeadFormProps) {
+  const [name, setName] = useState('')
+  const [phone, setPhone] = useState('')
+  const [curso, setCurso] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [done, setDone] = useState(false)
+  const [utm, setUtm] = useState<Record<string, string>>({})
+
+  // Captura UTMs/click-ids da URL (tráfego pago) uma vez no mount.
+  useEffect(() => {
+    const sp = new URLSearchParams(window.location.search)
+    const found: Record<string, string> = {}
+    for (const k of UTM_KEYS) {
+      const v = sp.get(k)
+      if (v) found[k] = v
+    }
+    setUtm(found)
+  }, [])
+
+  const canSubmit =
+    !submitting && name.trim().length >= 2 && phone.replace(/\D/g, '').length >= 10
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canSubmit) return
+    setSubmitting(true)
+    try {
+      await fetch('/api/ingressa', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          phone: phone.replace(/\D/g, ''),
+          partner,
+          partnerName,
+          curso: curso || null,
+          utm,
+        }),
+      })
+      // Dispara o pixel do browser (dedup com o CAPI server pelo eventID não é
+      // crítico aqui; o server já registra o Lead).
+      const w = window as unknown as { fbq?: (...a: unknown[]) => void }
+      if (typeof w.fbq === 'function') w.fbq('track', 'Lead', { content_name: partner })
+    } catch {
+      // best-effort: mostra sucesso mesmo se o registro falhar (não travar o lead)
+    } finally {
+      setDone(true)
+      setSubmitting(false)
+    }
+  }
+
+  if (done) {
+    return (
+      <div className="rounded-2xl bg-emerald-50 border border-emerald-200 p-6 text-center">
+        <CheckCircle2 className="mx-auto text-emerald-600 mb-3" size={32} />
+        <h3 className="font-display text-xl font-semibold text-ink-900 mb-1">Recebemos seu contato!</h3>
+        <p className="text-ink-700 text-sm">
+          Em breve nosso time entra em contato pra garantir sua bolsa na {partnerName}. Fique de olho no WhatsApp.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-2xl bg-white border border-hairline shadow-lg p-6 md:p-7 space-y-3">
+      <div>
+        <label htmlFor="lf-name" className="block text-xs font-mono uppercase tracking-wider text-ink-500 mb-1">
+          Seu nome
+        </label>
+        <input
+          id="lf-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          maxLength={80}
+          required
+          className="w-full px-3 py-2.5 bg-white border border-gray-200 rounded-md text-sm focus:ring-2 focus:ring-bolsa-secondary focus:border-transparent"
+        />
+      </div>
+      <div>
+        <label htmlFor="lf-phone" className="block text-xs font-mono uppercase tracking-wider text-ink-500 mb-1">
+          WhatsApp
+        </label>
+        <input
+          id="lf-phone"
+          type="tel"
+          value={phone}
+          onChange={(e) => setPhone(formatPhone(e.target.value))}
+          placeholder="(11) 99999-9999"
+          required
+          className="w-full px-3 py-2.5 bg-white border border-gray-200 rounded-md text-sm focus:ring-2 focus:ring-bolsa-secondary focus:border-transparent"
+        />
+      </div>
+      {courses.length > 0 && (
+        <div>
+          <label htmlFor="lf-curso" className="block text-xs font-mono uppercase tracking-wider text-ink-500 mb-1">
+            Curso de interesse <span className="normal-case tracking-normal text-ink-400">(opcional)</span>
+          </label>
+          <select
+            id="lf-curso"
+            value={curso}
+            onChange={(e) => setCurso(e.target.value)}
+            className="w-full px-3 py-2.5 bg-white border border-gray-200 rounded-md text-sm focus:ring-2 focus:ring-bolsa-secondary focus:border-transparent"
+          >
+            <option value="">Escolher depois</option>
+            {courses.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+      <button
+        type="submit"
+        disabled={!canSubmit}
+        className="w-full inline-flex items-center justify-center gap-2 px-5 py-3 bg-bolsa-secondary text-white text-base font-semibold rounded-md hover:opacity-90 disabled:opacity-40"
+      >
+        {submitting ? <Loader2 size={16} className="animate-spin" /> : null}
+        Quero minha bolsa na {partnerName}
+      </button>
+      <p className="text-[11px] text-ink-500 text-center">
+        Grátis e sem compromisso. Ao enviar, você concorda em ser contatado pelo Bolsa Click.
+      </p>
+    </form>
+  )
+}

--- a/app/lp/[partner]/page.tsx
+++ b/app/lp/[partner]/page.tsx
@@ -1,0 +1,206 @@
+import type { Metadata } from 'next'
+import Image from 'next/image'
+import { notFound } from 'next/navigation'
+import { CheckCircle2, ShieldCheck, Clock, Star } from 'lucide-react'
+import { prisma } from '@/app/lib/prisma'
+import { getInstitutionCourses } from '@/app/lib/api/get-institution-courses'
+import { BRAND_CONTENT } from '@/app/faculdades/[slug]/_data/brand-content'
+import { LeadForm } from './_components/LeadForm'
+
+export const revalidate = 3600
+
+const PARTNERS = ['anhanguera', 'unopar', 'pitagoras', 'unime', 'estacio']
+
+export async function generateStaticParams() {
+  const insts = await prisma.institution.findMany({
+    where: { isActive: true, slug: { in: PARTNERS } },
+    select: { slug: true },
+  })
+  return insts.map((i) => ({ partner: i.slug }))
+}
+
+const getInstitution = (slug: string) => prisma.institution.findUnique({ where: { slug } })
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ partner: string }>
+}): Promise<Metadata> {
+  const { partner } = await params
+  const inst = await getInstitution(partner)
+  if (!inst) return { title: 'Página não encontrada' }
+  return {
+    title: `Bolsa de até 80% na ${inst.name} — Inscreva-se grátis`,
+    description: `Garanta sua bolsa de estudo na ${inst.fullName} com até 80% de desconto. Sem ENEM, sem nota de corte. Fale com nosso time e comece a estudar.`,
+    robots: { index: false, follow: false },
+  }
+}
+
+function formatBRL(v: number): string {
+  return v.toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+}
+
+export default async function PartnerLanding({
+  params,
+}: {
+  params: Promise<{ partner: string }>
+}) {
+  const { partner } = await params
+  const inst = await getInstitution(partner)
+  if (!inst || !inst.isActive || !PARTNERS.includes(partner)) {
+    notFound()
+  }
+
+  const [courses] = await Promise.all([getInstitutionCourses(inst.name)])
+  const brand = BRAND_CONTENT[partner]
+
+  // Top cursos com preço real (ordenados pela mensalidade com bolsa).
+  const topCourses = courses
+    .filter((c) => Number(c.minPrice ?? 0) > 0)
+    .map((c) => ({ name: String(c.name ?? '').trim(), minPrice: Number(c.minPrice) }))
+    .filter((c) => c.name)
+    .sort((a, b) => a.minPrice - b.minPrice)
+    .slice(0, 6)
+  const courseNames = topCourses.map((c) => c.name)
+
+  const pontosFortes = brand?.valeAPena.pontosFortes ?? [
+    'Diploma reconhecido pelo MEC',
+    'Bolsas de até 80% sem nota de corte',
+    'Inscrição gratuita e sem ENEM',
+  ]
+
+  return (
+    <>
+      {/* HERO + FORM */}
+      <section className="relative bg-bolsa-primary overflow-hidden">
+        <div aria-hidden className="absolute -top-24 -right-32 w-[28rem] h-[28rem] rounded-full bg-bolsa-secondary/20 blur-3xl" />
+        <div className="container mx-auto px-4 py-10 md:py-16 relative">
+          <div className="grid lg:grid-cols-2 gap-8 md:gap-12 items-center">
+            {/* Copy */}
+            <div>
+              <div className="inline-flex items-center gap-3 bg-white rounded-xl px-4 py-2.5 mb-6">
+                {inst.logoUrl ? (
+                  <Image
+                    src={inst.logoUrl}
+                    alt={`Logo ${inst.name}`}
+                    width={120}
+                    height={36}
+                    className="h-8 w-auto object-contain"
+                  />
+                ) : (
+                  <span className="font-display font-semibold text-bolsa-primary text-lg">{inst.name}</span>
+                )}
+              </div>
+              <h1 className="font-display text-3xl sm:text-4xl md:text-5xl font-semibold text-white leading-[1.08] mb-4">
+                Bolsa de até <span className="text-bolsa-secondary">80%</span> na {inst.name}
+              </h1>
+              <p className="text-white/80 text-base md:text-lg leading-relaxed mb-6 max-w-xl">
+                Estude na {inst.fullName} pagando muito menos. Sem ENEM, sem nota de corte,
+                inscrição grátis. Preencha e nosso time garante sua bolsa.
+              </p>
+              <ul className="flex flex-wrap gap-x-5 gap-y-2 text-white/85 text-sm">
+                {inst.mecRating ? (
+                  <li className="inline-flex items-center gap-1.5">
+                    <Star size={15} className="text-bolsa-secondary" /> Nota {inst.mecRating}/5 no MEC
+                  </li>
+                ) : (
+                  <li className="inline-flex items-center gap-1.5">
+                    <ShieldCheck size={15} className="text-bolsa-secondary" /> Reconhecida pelo MEC
+                  </li>
+                )}
+                {inst.studentCount && (
+                  <li className="inline-flex items-center gap-1.5">
+                    <CheckCircle2 size={15} className="text-bolsa-secondary" /> {inst.studentCount} alunos
+                  </li>
+                )}
+                <li className="inline-flex items-center gap-1.5">
+                  <Clock size={15} className="text-bolsa-secondary" /> Resposta em minutos
+                </li>
+              </ul>
+            </div>
+
+            {/* Form */}
+            <div className="lg:pl-6">
+              <div className="mb-3 text-center">
+                <span className="inline-block font-mono text-[11px] tracking-[0.18em] uppercase text-white/70">
+                  Garanta sua bolsa agora
+                </span>
+              </div>
+              <LeadForm partner={partner} partnerName={inst.name} courses={courseNames} />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* OFERTAS REAIS */}
+      {topCourses.length > 0 && (
+        <section className="bg-white py-12 md:py-16 border-b border-hairline">
+          <div className="container mx-auto px-4 max-w-4xl">
+            <h2 className="font-display text-2xl md:text-3xl font-semibold text-ink-900 mb-2">
+              Cursos com bolsa na {inst.name}
+            </h2>
+            <p className="text-ink-700 mb-6">Mensalidades reais com a bolsa já aplicada — a partir de:</p>
+            <ul className="grid sm:grid-cols-2 gap-3">
+              {topCourses.map((c) => (
+                <li key={c.name} className="flex items-center justify-between gap-4 bg-paper border border-hairline rounded-lg px-4 py-3">
+                  <span className="font-display text-ink-900 truncate">{c.name}</span>
+                  <span className="font-display text-ink-900 whitespace-nowrap text-sm">
+                    a partir de <strong>{formatBRL(c.minPrice)}</strong>
+                    <span className="text-ink-500">/mês</span>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      )}
+
+      {/* POR QUE */}
+      <section className="bg-paper py-12 md:py-16">
+        <div className="container mx-auto px-4 max-w-4xl">
+          <h2 className="font-display text-2xl md:text-3xl font-semibold text-ink-900 mb-6">
+            Por que estudar na {inst.name}
+          </h2>
+          <ul className="grid sm:grid-cols-2 gap-3">
+            {pontosFortes.map((p, i) => (
+              <li key={i} className="flex gap-2.5 text-ink-700 leading-relaxed">
+                <CheckCircle2 size={20} className="text-bolsa-secondary shrink-0 mt-0.5" />
+                <span>{p}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      {/* CTA FINAL */}
+      <section className="bg-bolsa-primary py-12 md:py-16 text-center">
+        <div className="container mx-auto px-4 max-w-2xl">
+          <h2 className="font-display text-2xl md:text-3xl font-semibold text-white mb-3">
+            Sua bolsa na {inst.name} está esperando
+          </h2>
+          <p className="text-white/80 mb-7">
+            Preencha o formulário no topo e nosso time entra em contato pra garantir seu desconto de até 80%.
+          </p>
+          <a
+            href="#top"
+            className="inline-flex items-center justify-center px-7 py-3.5 bg-bolsa-secondary text-white font-semibold rounded-full hover:opacity-90"
+          >
+            Quero minha bolsa
+          </a>
+        </div>
+      </section>
+
+      <footer className="bg-white py-6 border-t border-hairline">
+        <div className="container mx-auto px-4 text-center text-[12px] text-ink-500">
+          {inst.fullName} é instituição parceira. Intermediação de bolsas por Bolsa Click. Descontos
+          e disponibilidade variam por curso, modalidade e unidade.
+        </div>
+      </footer>
+    </>
+  )
+}

--- a/app/lp/layout.tsx
+++ b/app/lp/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next'
+
+// Landings de conversão do ingressa.digital (tráfego pago). Servidas neste
+// caminho /lp/* e reescritas de ingressa.digital/{parceiro} pelo middleware.
+// NOINDEX: são páginas de anúncio, não devem competir/duplicar com o SEO do
+// bolsaclick.com.br. Layout minimal — sem a nav/footer do site principal.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
+
+export default function LpLayout({ children }: { children: React.ReactNode }) {
+  return <div className="min-h-screen bg-white text-ink-900">{children}</div>
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -29,6 +29,35 @@ export function middleware(request: NextRequest) {
   const { pathname, search } = request.nextUrl;
   const host = (request.headers.get("host") || "").split(":")[0];
 
+  // ─── Domínio ingressa.digital (landings de conversão / mídia paga) ───────────
+  // ingressa.digital/{parceiro} → reescreve (URL limpa) pra /lp/{parceiro}.
+  // /api, /_next e assets passam intactos; raiz vai pra uma landing default.
+  if (host === "ingressa.digital" || host === "www.ingressa.digital") {
+    const passthrough =
+      pathname.startsWith("/api") ||
+      pathname.startsWith("/_next") ||
+      pathname.startsWith("/lp") ||
+      pathname.includes(".");
+    if (!passthrough) {
+      const url = request.nextUrl.clone();
+      url.pathname = pathname === "/" ? "/lp/anhanguera" : `/lp${pathname}`;
+      return NextResponse.rewrite(url);
+    }
+    return NextResponse.next();
+  }
+
+  // No bolsaclick.com.br, /lp/* não deve ser acessível (é do ingressa) → manda
+  // pra página de marca equivalente.
+  if (
+    (host === "www.bolsaclick.com.br" || host === "bolsaclick.com.br") &&
+    pathname.startsWith("/lp/")
+  ) {
+    const url = publicRedirectUrl(request);
+    url.hostname = "www.bolsaclick.com.br";
+    url.pathname = pathname.replace(/^\/lp\//, "/faculdades/");
+    return NextResponse.redirect(url, 302);
+  }
+
   // Redirect non-www → www (301 permanent)
   if (host === "bolsaclick.com.br") {
     const url = publicRedirectUrl(request);


### PR DESCRIPTION
Landings de **conversão pra mídia paga** por parceiro, no domínio **ingressa.digital**, isoladas do SEO do bolsaclick (**noindex**, sem nav do site). Mesmo repo + deploy separado (conforme decidido).

## O que entra
- **`app/lp/[partner]/page.tsx`** — landing por parceiro (Anhanguera, Unopar, Pitágoras, Unime, Estácio): hero + logo, **ofertas reais** (`getInstitutionCourses`), prova social (nota MEC, alunos, pontos fortes do `brand-content`), form de lead. Reusa `Institution` + `BRAND_CONTENT`.
- **`LeadForm.tsx`** — nome + WhatsApp + curso; captura UTM/gclid/fbclid; dispara `fbq('Lead')`.
- **`app/api/ingressa/route.ts`** — Lead (source `ingressa-{parceiro}`, UTM no extraData) + Notealy + Meta CAPI, rate-limit por IP.
- **`app/lp/layout.tsx`** — minimal + `noindex`.
- **`middleware.ts`** — `ingressa.digital/{parceiro}` → **rewrite** pra `/lp/{parceiro}` (URL limpa; `/api` e assets intactos; raiz → landing default). `/lp/*` no bolsaclick redireciona pra `/faculdades/` (não vaza no SEO).

## Validação
tsc 0, eslint limpo. Runtime: landings dos 5 parceiros renderizam com ofertas reais; rewrite por host confirmado (`Host: ingressa.digital` + `/anhanguera` → landing); API valida (400); noindex presente.

## ⚠️ Infra (fora do código — você faz)
1. Criar um **serviço Railway** apontando pro **mesmo repo** (deploy independente).
2. Adicionar o domínio **ingressa.digital** (+ DNS) nesse serviço.
3. (Opcional) `NOTEALY_TAG_INGRESSA` e o pixel Meta do ingressa nas envs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)