### PR TITLE
feat(ingressa): rastreio pronto pra ads (dedup Pixel×CAPI + tag Notealy)

### DIFF
--- a/app/api/ingressa/route.ts
+++ b/app/api/ingressa/route.ts
@@ -3,6 +3,10 @@ import { prisma } from '@/app/lib/prisma'
 import { upsertNotealyContact } from '@/app/lib/api/notealy'
 import { sendFacebookEvent } from '@/app/lib/analytics/fb-capi'
 
+// Tag fixa do funil ingressa no Notealy (criada 2026-07-14). Hardcoded — não
+// depende de env.
+const NOTEALY_TAG_INGRESSA = '2efcf93c-f924-4b32-a3d0-37995d1b5d69'
+
 interface IngressaBody {
   name: string
   phone: string
@@ -10,6 +14,8 @@ interface IngressaBody {
   partnerName?: string
   curso?: string | null
   utm?: Record<string, string>
+  /** eventID gerado no browser p/ deduplicar Pixel (client) × CAPI (server). */
+  eventId?: string
 }
 
 // Rate-limit por IP (mesmo padrão do simulador/teste vocacional).
@@ -34,6 +40,7 @@ async function sendLeadToMeta(params: {
   name: string
   phone: string
   partner?: string
+  eventId?: string
   request: NextRequest
 }) {
   try {
@@ -44,7 +51,8 @@ async function sendLeadToMeta(params: {
       undefined
     await sendFacebookEvent({
       eventName: 'Lead',
-      eventId: `ingressa_${params.leadId}`,
+      // Mesmo eventID do Pixel do browser → o Meta deduplica (não conta 2×).
+      eventId: params.eventId || `ingressa_${params.leadId}`,
       userData: {
         phone: params.phone,
         firstName: firstName || undefined,
@@ -119,7 +127,7 @@ export async function POST(request: NextRequest) {
     await upsertNotealyContact({
       name: cleanName,
       phone: cleanPhone,
-      tagId: process.env.NOTEALY_TAG_INGRESSA ?? process.env.NOTEALY_TAG_LEAD,
+      tagId: NOTEALY_TAG_INGRESSA,
     })
   } catch (error) {
     console.error('⚠️ Notealy (ingressa) falhou:', error)
@@ -127,7 +135,7 @@ export async function POST(request: NextRequest) {
 
   // 3) Meta CAPI (best-effort).
   if (leadId) {
-    await sendLeadToMeta({ leadId, name: cleanName, phone: cleanPhone, partner: partnerSlug, request })
+    await sendLeadToMeta({ leadId, name: cleanName, phone: cleanPhone, partner: partnerSlug, eventId: body.eventId, request })
   }
 
   return NextResponse.json({ ok: true }, { status: 201 })

--- a/app/lp/[partner]/_components/LeadForm.tsx
+++ b/app/lp/[partner]/_components/LeadForm.tsx
@@ -46,6 +46,12 @@ export function LeadForm({ partner, partnerName, courses, accentColor = '#023e73
     e.preventDefault()
     if (!canSubmit) return
     setSubmitting(true)
+    // eventID único compartilhado entre o Pixel (browser) e o CAPI (server) →
+    // o Meta deduplica o Lead (não conta a conversão em dobro).
+    const eventId =
+      typeof crypto !== 'undefined' && crypto.randomUUID
+        ? crypto.randomUUID()
+        : `ing_${Date.now()}_${Math.round(Math.random() * 1e9)}`
     try {
       await fetch('/api/ingressa', {
         method: 'POST',
@@ -57,12 +63,14 @@ export function LeadForm({ partner, partnerName, courses, accentColor = '#023e73
           partnerName,
           curso: curso || null,
           utm,
+          eventId,
         }),
       })
-      // Dispara o pixel do browser (dedup com o CAPI server pelo eventID não é
-      // crítico aqui; o server já registra o Lead).
+      // Pixel do browser com o MESMO eventID → dedup com o CAPI server.
       const w = window as unknown as { fbq?: (...a: unknown[]) => void }
-      if (typeof w.fbq === 'function') w.fbq('track', 'Lead', { content_name: partner })
+      if (typeof w.fbq === 'function') {
+        w.fbq('track', 'Lead', { content_name: partner }, { eventID: eventId })
+      }
     } catch {
       // best-effort: mostra sucesso mesmo se o registro falhar (não travar o lead)
     } finally {


### PR DESCRIPTION
Deixa as landings do ingressa prontas pra rodar anúncio com conversão rastreável.

- **Dedup Pixel × CAPI:** um `eventID` único é gerado no browser, enviado ao `/api/ingressa` e usado no `fbq('Lead')` (Pixel do browser) **e** no Meta CAPI (server) → o Meta reconhece como o mesmo evento e não conta a conversão em dobro (essencial pra otimização de ads).
- **Tag Notealy `ingressa`** criada e fixada (`2efcf93c-...`) — os leads do ingressa ficam etiquetados à parte no CRM.

O Pixel do browser já é carregado (o root layout injeta o `AnalyticsScripts`, herdado pelas `/lp`). tsc 0, eslint limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)