### PR TITLE
chore(seo): cron semanal do InstitutionCityOfferCache (marca×cidade)

### DIFF
--- a/.github/workflows/precompute-institution-city-offers.yml
+++ b/.github/workflows/precompute-institution-city-offers.yml
@@ -1,0 +1,55 @@
+name: Precompute institution city offers
+
+# Mantém InstitutionCityOfferCache fresco — fonte de verdade do gate de indexação
+# das páginas de marca por cidade (app/faculdades/[slug]/em/[city]) e da emissão
+# do sitemap de instituições. Sem isso o cache envelhece: cidades que perderam
+# oferta continuam indexadas (thin) e cidades que ganharam oferta ficam dormentes.
+# Roda no GitHub Actions (não na Vercel/Railway) porque é job de minutos-a-horas e
+# varre o Brasil inteiro — uma busca por cidade agrupando todas as marcas.
+#
+# Difere do "precompute-city-offers" (curso×cidade, só Tartarus): aqui também
+# consultamos a Athena (Estácio/YDUQS), então exige o secret ATHENA_BASE_URL.
+
+on:
+  schedule:
+    # Semanal — domingo 04:17 UTC (~01:17 BRT). 1h depois do precompute de curso
+    # (03:17) pra não dobrar a carga na Tartarus rodando os dois juntos.
+    - cron: '17 4 * * 0'
+  workflow_dispatch:
+    inputs:
+      city_limit:
+        description: 'Cidades a varrer (top N; vazio = todas)'
+        required: false
+        default: ''
+      concurrency:
+        description: 'Cidades em paralelo'
+        required: false
+        default: '4'
+
+# Evita duas execuções simultâneas escrevendo no mesmo cache.
+concurrency:
+  group: precompute-institution-city-offers
+  cancel-in-progress: false
+
+jobs:
+  precompute:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx prisma generate
+      - name: Precompute InstitutionCityOfferCache
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          NEXT_PUBLIC_TARTARUS_API: ${{ secrets.NEXT_PUBLIC_TARTARUS_API }}
+          # Athena (Estácio/YDUQS) — sem esse secret a Estácio fica sem inventário
+          # e a superfície dela permanece dormente (comportamento seguro).
+          ATHENA_BASE_URL: ${{ secrets.ATHENA_BASE_URL }}
+          CITY_LIMIT: ${{ github.event.inputs.city_limit }}
+          CONCURRENCY: ${{ github.event.inputs.concurrency || '4' }}
+        run: npx tsx scripts/precompute-institution-city-offers.ts

--- a/scripts/precompute-institution-city-offers.ts
+++ b/scripts/precompute-institution-city-offers.ts
@@ -28,8 +28,13 @@ import { TOP_CURSOS } from '../app/cursos/_data/cursos'
 const prisma = new PrismaClient()
 
 const DRY_RUN = process.argv.includes('--dry-run')
-const arg = (k: string) =>
-  process.argv.find((a) => a.startsWith(`${k}=`))?.split('=')[1] ?? process.env[k]
+const arg = (k: string) => {
+  // Trata "" (env setada mas vazia, ex.: input opcional do GitHub Actions) como
+  // ausente — senão Number("") vira 0 e o cron varreria 0 cidades.
+  const fromArgv = process.argv.find((a) => a.startsWith(`${k}=`))?.split('=')[1]
+  const raw = fromArgv ?? process.env[k]
+  return raw && raw.trim() !== '' ? raw : undefined
+}
 const CITY_LIMIT = Number(arg('CITY_LIMIT') ?? BRAZILIAN_CITIES.length)
 const CONCURRENCY = Number(arg('CONCURRENCY') ?? 4)
 const PAGE_SIZE = 50


### PR DESCRIPTION
## O quê
Agenda um **GitHub Actions semanal** (domingo 04:17 UTC) que roda `scripts/precompute-institution-city-offers.ts`, mantendo o `InstitutionCityOfferCache` fresco.

## Por quê
As **567 city pages de marca** (`/faculdades/[slug]/em/[city]`) e o sitemap de instituições usam esse cache como **fonte de verdade do gate index/noindex**. Sem refresh periódico o snapshot envelhece:
- cidade que **perdeu** oferta continua indexada → vira thin content (risco de penalty);
- cidade que **ganhou** oferta nova fica dormente (deixamos tráfego na mesa).

Espelha o workflow já existente de curso×cidade (`precompute-city-offers.yml`), agendado **1h depois** pra não dobrar a carga na Tartarus, e com **um secret a mais**: `ATHENA_BASE_URL` (inventário da Estácio/YDUQS via Athena).

## Fix junto
Blindei o parsing de `CITY_LIMIT`: o input opcional do Actions chega como env vazia `""`, e `Number("" ?? todas)` resultava em **`Number("")` = 0** → o cron varreria **0 cidades** silenciosamente. Agora `""` é tratado como ausente (= todas as cidades).

## Validação
Dry-run local com `CITY_LIMIT=2`: varreu 2 cidades corretamente, Estácio via Athena retornou inventário (20 ofertas Rio/SP). ✅

## ⚠️ Ação necessária (você, admin do repo)
O workflow precisa do secret **`ATHENA_BASE_URL`** no GitHub (Settings → Secrets and variables → Actions). `DATABASE_URL` e `NEXT_PUBLIC_TARTARUS_API` já existem (o workflow de curso os usa). Se `ATHENA_BASE_URL` faltar, o cron roda mesmo assim — só a **Estácio** fica sem inventário (comportamento seguro/dormente), as 4 marcas Cogna continuam atualizando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)