### PR TITLE
fix(seo): técnico do audit — link morto + IndexNow consolidado e ampliado

### DIFF
--- a/app/lib/indexnow.ts
+++ b/app/lib/indexnow.ts
@@ -3,10 +3,15 @@
 //
 // Uso típico (em server actions ou route handlers de admin/CMS):
 //   await submitToIndexNow(['https://www.bolsaclick.com.br/blog/meu-post'])
+//
+// CONSOLIDAÇÃO (2026-07): havia DUAS implementações de IndexNow com CHAVES
+// DIFERENTES (esta com f631…, e app/lib/seo/indexnow com 6c3c…), o que a
+// auditoria SEO flagou como fragmentação. Agora este módulo delega pro canônico
+// (seo/indexnow, chave 6c3c…) — uma única chave e um único code path. Este
+// wrapper mantém a interface `IndexNowResult` + a validação de host (que o
+// endpoint público /api/indexnow usa) por compatibilidade.
 
-const INDEXNOW_KEY = process.env.INDEXNOW_KEY ?? 'f631d024680f4f78b5a196f16be58e9a'
-const SITE_HOST = 'www.bolsaclick.com.br'
-const KEY_LOCATION = `https://${SITE_HOST}/${INDEXNOW_KEY}.txt`
+import { pingIndexNow, INDEXNOW_HOST } from '@/app/lib/seo/indexnow'
 
 export interface IndexNowResult {
   ok: boolean
@@ -22,8 +27,7 @@ export async function submitToIndexNow(urls: string[]): Promise<IndexNowResult> 
 
   const validUrls = urls.filter((u) => {
     try {
-      const parsed = new URL(u)
-      return parsed.host === SITE_HOST
+      return new URL(u).host === INDEXNOW_HOST
     } catch {
       return false
     }
@@ -33,29 +37,11 @@ export async function submitToIndexNow(urls: string[]): Promise<IndexNowResult> 
     return { ok: false, status: 400, submitted: 0, message: 'No URLs match the configured host' }
   }
 
-  try {
-    const res = await fetch('https://api.indexnow.org/IndexNow', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json; charset=utf-8' },
-      body: JSON.stringify({
-        host: SITE_HOST,
-        key: INDEXNOW_KEY,
-        keyLocation: KEY_LOCATION,
-        urlList: validUrls,
-      }),
-    })
-    return {
-      ok: res.ok,
-      status: res.status,
-      submitted: validUrls.length,
-      message: res.ok ? 'Submitted' : await res.text().catch(() => 'Unknown error'),
-    }
-  } catch (e) {
-    return {
-      ok: false,
-      status: 0,
-      submitted: 0,
-      message: e instanceof Error ? e.message : 'Network error',
-    }
+  const result = await pingIndexNow(validUrls)
+  return {
+    ok: result.ok,
+    status: result.status,
+    submitted: result.ok ? result.urls : 0,
+    message: result.ok ? 'Submitted' : (result.reason ?? `IndexNow status ${result.status}`),
   }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -185,10 +185,17 @@ const nextConfig: NextConfig = {
       ['cst-em-mecatronica-industrial', 'mecatronica-industrial-tecnologo'],
       ['cst-em-automacao-industrial', 'automacao-industrial-tecnologo'],
     ]
-    return courseDupes.flatMap(([from, to]) => [
-      { source: `/cursos/${from}`, destination: `/cursos/${to}`, permanent: true },
-      { source: `/carreiras/${from}`, destination: `/carreiras/${to}`, permanent: true },
-    ])
+    return [
+      ...courseDupes.flatMap(([from, to]) => [
+        { source: `/cursos/${from}`, destination: `/cursos/${to}`, permanent: true },
+        { source: `/carreiras/${from}`, destination: `/carreiras/${to}`, permanent: true },
+      ]),
+      // URL "natural" que não existe (a central de ajuda é /central-de-ajuda).
+      // 301 pra não devolver 404 a backlink externo/citação que chute esse path
+      // (a auditoria GEO flagou o /perguntas-frequentes → 404).
+      { source: '/perguntas-frequentes', destination: '/central-de-ajuda', permanent: true },
+      { source: '/faq/perguntas-frequentes', destination: '/central-de-ajuda', permanent: true },
+    ]
   },
   // This is required to support PostHog trailing slash API requests
   skipTrailingSlashRedirect: true,

--- a/scripts/precompute-institution-city-offers.ts
+++ b/scripts/precompute-institution-city-offers.ts
@@ -22,6 +22,8 @@ import { PrismaClient } from '@prisma/client'
 import axios from 'axios'
 import { BRAZILIAN_CITIES } from '../app/lib/constants/brazilian-cities'
 import { normalizeBrand } from '../app/lib/utils/brand'
+import { pingIndexNow } from '../app/lib/seo/indexnow'
+import { MIN_OFFERS_TO_INDEX_INSTITUTION } from '../app/lib/seo/city-page-gate'
 import { searchAthenaOffers, normalizeAthenaOffer } from '../app/lib/api/athena-offers'
 import { TOP_CURSOS } from '../app/cursos/_data/cursos'
 
@@ -144,6 +146,11 @@ async function main() {
 
   let upserts = 0
   const brandTotals = new Map<string, number>() // slug → nº de cidades com >=1 oferta
+  // URLs de marca×cidade que ficaram indexáveis (offerCount ≥ threshold) — pra
+  // pingar o IndexNow no fim (Bing/Yandex + AI Overviews descobrem sem esperar o
+  // crawl do sitemap). Fecha o gap do audit: antes só blog/help pingavam.
+  const SITE_URL = 'https://www.bolsaclick.com.br'
+  const indexableUrls: string[] = []
 
   await pMap(
     cities,
@@ -178,6 +185,9 @@ async function main() {
           update: { offerCount: agg.count, minPrice: agg.min, fetchedAt: new Date() },
         })
         upserts++
+        if (agg.count >= MIN_OFFERS_TO_INDEX_INSTITUTION) {
+          indexableUrls.push(`${SITE_URL}/faculdades/${slug}/em/${city.slug}`)
+        }
       }
     },
     CONCURRENCY
@@ -188,6 +198,22 @@ async function main() {
     console.log(`  ${slug}: ${n} cidades`)
   }
   console.log(`\n${DRY_RUN ? '(dry-run, nada escrito)' : `upserts: ${upserts}`}`)
+
+  // Ping IndexNow (best-effort) das city pages de marca indexáveis. Em lotes de
+  // 1.000 pra resposta rápida. Nunca derruba o job (só loga).
+  if (!DRY_RUN && indexableUrls.length > 0) {
+    console.log(`\n─── IndexNow: pingando ${indexableUrls.length} city pages indexáveis ───`)
+    for (let i = 0; i < indexableUrls.length; i += 1000) {
+      const batch = indexableUrls.slice(i, i + 1000)
+      try {
+        const r = await pingIndexNow(batch)
+        console.log(`  lote ${i / 1000 + 1}: ${batch.length} URLs → status ${r.status} (${r.ok ? 'ok' : 'falhou'})`)
+      } catch (e) {
+        console.error(`  lote ${i / 1000 + 1}: erro`, e instanceof Error ? e.message : e)
+      }
+    }
+  }
+
   await prisma.$disconnect()
 }
 


### PR DESCRIPTION
PR de **SEO técnico** do rollout pós-auditoria. Só código, 0 migration.

## 1. Link morto `/perguntas-frequentes` → 404 (P1, GEO)
Não é linkado internamente, mas é um path "natural" — backlink/citação externa que o chute batia em 404. Redirect **301 → `/central-de-ajuda`** no `next.config` (+ variante `/faq/perguntas-frequentes`).

## 2. IndexNow fragmentado (P1, técnico)
Havia **duas implementações com chaves diferentes**: `app/lib/indexnow.ts` (`f631…`, usada pelo endpoint `/api/indexnow`) e `app/lib/seo/indexnow.ts` (`6c3c…`, usada por blog/help). Consolidado: `lib/indexnow` agora **delega pro canônico** (`seo/indexnow`, chave `6c3c…`) — 1 chave, 1 code path — mantendo a interface `IndexNowResult` + a validação de host que o `/api/indexnow` usa. Nenhum endpoint removido (o `/api/indexnow` é externo, protegido por secret). Os dois key-files seguem em `/public`.

## 3. IndexNow não cobria curso/instituição/city page (P1, técnico)
Antes só blog/help pingavam; as 561 city pages de marca dependiam só do crawl do sitemap. Agora o **precompute semanal** (`precompute-institution-city-offers`) pinga o IndexNow das city pages que ficaram indexáveis (`offerCount ≥ MIN_OFFERS_TO_INDEX_INSTITUTION`), em lotes de 1.000, **best-effort** (nunca derruba o job). Bing/Yandex + AI Overviews descobrem sem esperar o sitemap.

## ⚠️ Fora de código — ação sua no Cloudflare (P0 do audit)
O redirect **http/non-www com 2 hops** é **edge**, não código:
- hop 1 `http→https` = Cloudflare "Always Use HTTPS"
- hop 2 `non-www→www` = middleware do Next (origin)

Colapsar num **Redirect Rule** do Cloudflare: `http(s)://bolsaclick.com.br/*` → `https://www.bolsaclick.com.br/$1` (301). Isso substitui os dois hops por um só (menos latência, preserva link equity de backlinks no domínio nu).

## Validação
`tsc --noEmit` limpo. Dry-run do precompute OK (imports resolvem; o ping é gated por `!dry-run`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)