### PR TITLE
feat(ingressa): landings de conversão por curso (parceiro × curso)

### DIFF
--- a/app/lp/[partner]/[curso]/page.tsx
+++ b/app/lp/[partner]/[curso]/page.tsx
@@ -5,35 +5,34 @@ import { CheckCircle2, ShieldCheck, Clock, Star } from 'lucide-react'
 import { prisma } from '@/app/lib/prisma'
 import { getInstitutionCourses } from '@/app/lib/api/get-institution-courses'
 import { BRAND_CONTENT } from '@/app/faculdades/[slug]/_data/brand-content'
-import { LeadForm } from './_components/LeadForm'
-import { PARTNERS, brandColorFor } from '../_shared/partners'
+import { LeadForm } from '../_components/LeadForm'
+import { isPartner, brandColorFor } from '../../_shared/partners'
 
 export const revalidate = 3600
 
-export async function generateStaticParams() {
-  const insts = await prisma.institution.findMany({
-    where: { isActive: true, slug: { in: PARTNERS } },
-    select: { slug: true },
-  })
-  return insts.map((i) => ({ partner: i.slug }))
+// Landings de CURSO por parceiro (mídia paga): ingressa.digital/{parceiro}/{curso}.
+// O middleware reescreve pra /lp/{parceiro}/{curso}. Cobre TODOS os cursos do
+// catálogo (FeaturedCourse) por parceiro — geração dinâmica sob demanda (são
+// noindex, o tráfego vem de anúncio, não de crawl).
+
+type Props = { params: Promise<{ partner: string; curso: string }> }
+
+function normalize(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
 const getInstitution = (slug: string) => prisma.institution.findUnique({ where: { slug } })
 
-export async function generateMetadata({
-  params,
-}: {
-  params: Promise<{ partner: string }>
-}): Promise<Metadata> {
-  const { partner } = await params
-  const inst = await getInstitution(partner)
-  if (!inst) return { title: 'Página não encontrada' }
-  return {
-    title: `Bolsa de até 80% na ${inst.name} — Inscreva-se grátis`,
-    description: `Garanta sua bolsa de estudo na ${inst.fullName} com até 80% de desconto. Sem ENEM, sem nota de corte. Fale com nosso time e comece a estudar.`,
-    robots: { index: false, follow: false },
-  }
-}
+const getCourse = (slug: string) =>
+  prisma.featuredCourse.findFirst({
+    where: { slug, isActive: true },
+    select: { name: true, fullName: true, apiCourseName: true },
+  })
 
 function formatBRL(v: number): string {
   return v.toLocaleString('pt-BR', {
@@ -44,41 +43,53 @@ function formatBRL(v: number): string {
   })
 }
 
-export default async function PartnerLanding({
-  params,
-}: {
-  params: Promise<{ partner: string }>
-}) {
-  const { partner } = await params
-  const inst = await getInstitution(partner)
-  if (!inst || !inst.isActive || !PARTNERS.includes(partner)) {
-    notFound()
-  }
+/** Menor mensalidade da oferta do parceiro pro curso alvo (0 = sem preço). */
+function partnerCoursePrice(courses: { name?: string; minPrice?: number }[], apiCourseName: string): number {
+  const target = normalize(apiCourseName)
+  const matches = courses.filter((c) => {
+    const n = normalize(String(c.name ?? ''))
+    return n === target || n.startsWith(`${target} `) || n.startsWith(`${target}-`) || n.includes(target)
+  })
+  const prices = matches.map((c) => Number(c.minPrice ?? 0)).filter((p) => p > 0)
+  return prices.length ? Math.min(...prices) : 0
+}
 
-  const [courses, catalog] = await Promise.all([
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { partner, curso } = await params
+  const [inst, course] = await Promise.all([getInstitution(partner), getCourse(curso)])
+  if (!inst || !course) return { title: 'Página não encontrada', robots: { index: false, follow: false } }
+  return {
+    title: `Bolsa em ${course.name} na ${inst.name} — até 80% de desconto`,
+    description: `Garanta sua bolsa em ${course.name} na ${inst.fullName} com até 80% de desconto. Sem ENEM, sem nota de corte, inscrição grátis. Fale com nosso time.`,
+    robots: { index: false, follow: false },
+  }
+}
+
+export default async function PartnerCourseLanding({ params }: Props) {
+  const { partner, curso } = await params
+  if (!isPartner(partner)) notFound()
+
+  const [inst, course] = await Promise.all([getInstitution(partner), getCourse(curso)])
+  if (!inst || !inst.isActive || !course) notFound()
+
+  const [offers, catalog] = await Promise.all([
     getInstitutionCourses(inst.name),
-    // Catálogo completo do site (FeaturedCourse) pro dropdown "curso de interesse"
-    // — todos os cursos, não só os do parceiro, pra o lead escolher exatamente.
     prisma.featuredCourse.findMany({
       where: { isActive: true },
       select: { name: true },
       orderBy: { name: 'asc' },
     }),
   ])
-  const brand = BRAND_CONTENT[partner]
+
   const brandColor = brandColorFor(partner)
-  const courseOptions = Array.from(
-    new Set(catalog.map((c) => c.name.trim()).filter(Boolean))
-  )
+  const minPrice = partnerCoursePrice(offers, course.apiCourseName)
+  const courseOptions = Array.from(new Set(catalog.map((c) => c.name.trim()).filter(Boolean)))
+  // Garante que o curso da landing esteja no dropdown (pré-selecionado).
+  if (!courseOptions.some((c) => normalize(c) === normalize(course.name))) {
+    courseOptions.unshift(course.name)
+  }
 
-  // Top cursos com preço real (ordenados pela mensalidade com bolsa).
-  const topCourses = courses
-    .filter((c) => Number(c.minPrice ?? 0) > 0)
-    .map((c) => ({ name: String(c.name ?? '').trim(), minPrice: Number(c.minPrice) }))
-    .filter((c) => c.name)
-    .sort((a, b) => a.minPrice - b.minPrice)
-    .slice(0, 6)
-
+  const brand = BRAND_CONTENT[partner]
   const pontosFortes = brand?.valeAPena.pontosFortes ?? [
     'Diploma reconhecido pelo MEC',
     'Bolsas de até 80% sem nota de corte',
@@ -108,13 +119,18 @@ export default async function PartnerLanding({
                 )}
               </div>
               <h1 className="font-display text-3xl sm:text-4xl md:text-5xl font-semibold text-white leading-[1.08] mb-4">
-                Bolsa de até <span className="underline decoration-white/40 decoration-[3px] underline-offset-4">80%</span> na {inst.name}
+                Bolsa em <span className="underline decoration-white/40 decoration-[3px] underline-offset-4">{course.name}</span> na {inst.name}
               </h1>
               <p className="text-white/80 text-base md:text-lg leading-relaxed mb-6 max-w-xl">
-                Estude na {inst.fullName} pagando muito menos. Sem ENEM, sem nota de corte,
-                inscrição grátis. Preencha e nosso time garante sua bolsa.
+                Estude {course.name} na {inst.fullName} pagando muito menos. Bolsa de até 80%, sem ENEM,
+                sem nota de corte, inscrição grátis. Preencha e nosso time garante sua vaga.
               </p>
               <ul className="flex flex-wrap gap-x-5 gap-y-2 text-white/85 text-sm">
+                {minPrice > 0 && (
+                  <li className="inline-flex items-center gap-1.5">
+                    <Star size={15} className="text-white/80" /> A partir de {formatBRL(minPrice)}/mês
+                  </li>
+                )}
                 {inst.mecRating ? (
                   <li className="inline-flex items-center gap-1.5">
                     <Star size={15} className="text-white/80" /> Nota {inst.mecRating}/5 no MEC
@@ -122,11 +138,6 @@ export default async function PartnerLanding({
                 ) : (
                   <li className="inline-flex items-center gap-1.5">
                     <ShieldCheck size={15} className="text-white/80" /> Reconhecida pelo MEC
-                  </li>
-                )}
-                {inst.studentCount && (
-                  <li className="inline-flex items-center gap-1.5">
-                    <CheckCircle2 size={15} className="text-white/80" /> {inst.studentCount} alunos
                   </li>
                 )}
                 <li className="inline-flex items-center gap-1.5">
@@ -139,43 +150,26 @@ export default async function PartnerLanding({
             <div className="lg:pl-6">
               <div className="mb-3 text-center">
                 <span className="inline-block font-mono text-[11px] tracking-[0.18em] uppercase text-white/70">
-                  Garanta sua bolsa agora
+                  Garanta sua bolsa em {course.name}
                 </span>
               </div>
-              <LeadForm partner={partner} partnerName={inst.name} courses={courseOptions} accentColor={brandColor} />
+              <LeadForm
+                partner={partner}
+                partnerName={inst.name}
+                courses={courseOptions}
+                accentColor={brandColor}
+                defaultCurso={course.name}
+              />
             </div>
           </div>
         </div>
       </section>
 
-      {/* OFERTAS REAIS */}
-      {topCourses.length > 0 && (
-        <section className="bg-white py-12 md:py-16 border-b border-hairline">
-          <div className="container mx-auto px-4 max-w-4xl">
-            <h2 className="font-display text-2xl md:text-3xl font-semibold text-ink-900 mb-2">
-              Cursos com bolsa na {inst.name}
-            </h2>
-            <p className="text-ink-700 mb-6">Mensalidades reais com a bolsa já aplicada — a partir de:</p>
-            <ul className="grid sm:grid-cols-2 gap-3">
-              {topCourses.map((c) => (
-                <li key={c.name} className="flex items-center justify-between gap-4 bg-paper border border-hairline rounded-lg px-4 py-3">
-                  <span className="font-display text-ink-900 truncate">{c.name}</span>
-                  <span className="font-display text-ink-900 whitespace-nowrap text-sm">
-                    a partir de <strong>{formatBRL(c.minPrice)}</strong>
-                    <span className="text-ink-500">/mês</span>
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </section>
-      )}
-
       {/* POR QUE */}
       <section className="bg-paper py-12 md:py-16">
         <div className="container mx-auto px-4 max-w-4xl">
           <h2 className="font-display text-2xl md:text-3xl font-semibold text-ink-900 mb-6">
-            Por que estudar na {inst.name}
+            Por que estudar {course.name} na {inst.name}
           </h2>
           <ul className="grid sm:grid-cols-2 gap-3">
             {pontosFortes.map((p, i) => (
@@ -192,7 +186,7 @@ export default async function PartnerLanding({
       <section className="py-12 md:py-16 text-center" style={{ backgroundColor: brandColor }}>
         <div className="container mx-auto px-4 max-w-2xl">
           <h2 className="font-display text-2xl md:text-3xl font-semibold text-white mb-3">
-            Sua bolsa na {inst.name} está esperando
+            Sua bolsa em {course.name} está esperando
           </h2>
           <p className="text-white/80 mb-7">
             Preencha o formulário no topo e nosso time entra em contato pra garantir seu desconto de até 80%.

--- a/app/lp/[partner]/_components/LeadForm.tsx
+++ b/app/lp/[partner]/_components/LeadForm.tsx
@@ -8,6 +8,8 @@ interface LeadFormProps {
   partnerName: string
   courses: string[]
   accentColor?: string
+  /** Curso pré-selecionado (landing de curso). Deve existir em `courses`. */
+  defaultCurso?: string
 }
 
 function formatPhone(value: string): string {
@@ -20,10 +22,10 @@ function formatPhone(value: string): string {
 
 const UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'fbclid']
 
-export function LeadForm({ partner, partnerName, courses, accentColor = '#023e73' }: LeadFormProps) {
+export function LeadForm({ partner, partnerName, courses, accentColor = '#023e73', defaultCurso = '' }: LeadFormProps) {
   const [name, setName] = useState('')
   const [phone, setPhone] = useState('')
-  const [curso, setCurso] = useState('')
+  const [curso, setCurso] = useState(defaultCurso)
   const [submitting, setSubmitting] = useState(false)
   const [done, setDone] = useState(false)
   const [utm, setUtm] = useState<Record<string, string>>({})

--- a/app/lp/_shared/partners.ts
+++ b/app/lp/_shared/partners.ts
@@ -1,0 +1,25 @@
+// Fonte de verdade dos parceiros do ingressa (landings de conversão / mídia
+// paga) — usada pela landing de marca (/lp/[partner]) e pela de curso
+// (/lp/[partner]/[curso]) pra não duplicar/derivar cor de marca.
+
+export const PARTNERS: string[] = ['anhanguera', 'unopar', 'pitagoras', 'unime', 'estacio']
+
+// Cor de marca por parceiro (extraída dos sites oficiais / do concorrente
+// matricula.digital). Hero, acentos e CTA usam essa cor — a landing fica com a
+// cara da marca, o que converte melhor no tráfego de anúncio de brand.
+export const DEFAULT_BRAND = '#023e73'
+export const PARTNER_BRAND: Record<string, string> = {
+  anhanguera: '#f94d12', // laranja (site oficial)
+  estacio: '#022549', // navy (matricula.digital)
+  unopar: '#0a3c7d', // azul (site oficial)
+  pitagoras: '#e2521d', // laranja-vermelho (site oficial)
+  unime: '#e31b22', // vermelho (unime.edu.br)
+}
+
+export function brandColorFor(partner: string): string {
+  return PARTNER_BRAND[partner] ?? DEFAULT_BRAND
+}
+
+export function isPartner(slug: string): boolean {
+  return PARTNERS.includes(slug)
+}


### PR DESCRIPTION
Expande o **ingressa** (mídia paga) com **landings de curso por parceiro** — pra anúncios de curso específico.

## URL e roteamento
`ingressa.digital/{parceiro}/{curso}` → rota `app/lp/[partner]/[curso]/page.tsx`. **Sem mudança no middleware** — ele já reescreve multi-segmento (`/lp${pathname}`), então `/anhanguera/enfermagem-bacharelado` → `/lp/anhanguera/enfermagem-bacharelado` automaticamente.

## Cobertura: todos os cursos da API
- Cobre **todos os cursos do catálogo** (`FeaturedCourse`, **177 ativos**) × 5 parceiros (~885 combos), **dinâmicos sob demanda** — são `noindex` (mídia paga), o tráfego vem de anúncio, não de crawl, então não precisa pré-gerar.
- Casa o slug do curso com a **oferta real da API do parceiro** (`getInstitutionCourses`) → mostra a menor mensalidade quando disponível. Sem preço (curso fora do TOP_CURSOS), renderiza qualitativo — sempre funciona pra anúncio.

## Consistência com a landing de marca
- **Tema de marca** (cor do parceiro) no hero/acentos/CTA.
- **LeadForm** com o curso **pré-selecionado** (nova prop `defaultCurso`), mantendo o dropdown do catálogo completo e o mesmo tracking (UTM/gclid/fbclid + Pixel×CAPI dedup + tag Notealy `ingressa`).
- Extraí `PARTNERS` + `PARTNER_BRAND` pra `app/lp/_shared/partners.ts` (fonte única) — a landing de marca passa a importar de lá, evitando drift das cores.

## Exemplos
- `ingressa.digital/anhanguera/enfermagem-bacharelado`
- `ingressa.digital/estacio/analise-e-desenvolvimento-de-sistemas-tecnologo`
- `ingressa.digital/unopar/administracao-bacharelado`

## Validação
`tsc --noEmit` limpo. Independente das outras PRs abertas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)